### PR TITLE
Restricted commits on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
     -   id: end-of-file-fixer
     -   id: mixed-line-ending
     -   id: trailing-whitespace
+    -   id: no-commit-to-branch
+        args: ['--branch', 'main']
 #####
 # Python
 -   repo: https://github.com/psf/black


### PR DESCRIPTION
## Overview
We don't want to allow accidental changes to main and therefore want to prevent commits.

## Changes
Added `no-commit-to-branch` line to the pre-commit repo calls.