### PR TITLE
Skeleton of transmission model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2021"
 clap = { version = "4.5.21", features = ["derive"] }
 ctor = "0.2.9"
 csv = "1.3.1"
+ctor = "0.2.9"
 ixa = { git = "https://github.com/cdcgov/ixa", version = "0.0.1" }
 ixa-derive = { git = "https://github.com/cdcgov/ixa", version = "0.0.0" }
 paste = "1.0.15"
+rand = "0.8.5"
 serde = "1.0.215"
 serde_derive = "1.0.215"
 tempfile = "3.14.0"
+statrs = "0.17.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 clap = { version = "4.5.21", features = ["derive"] }
 ctor = "0.2.9"
 csv = "1.3.1"
-ctor = "0.2.9"
 ixa = { git = "https://github.com/cdcgov/ixa", version = "0.0.1" }
 ixa-derive = { git = "https://github.com/cdcgov/ixa", version = "0.0.0" }
 paste = "1.0.15"

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,0 +1,105 @@
+use ixa::{
+    context::Context,
+    define_rng,
+    error::IxaError,
+    people::{ContextPeopleExt, PersonId},
+    random::ContextRandomExt,
+};
+use statrs::distribution::Categorical;
+
+use crate::population_loader::Alive;
+
+define_rng!(ContactRng);
+
+pub trait QueryContacts {
+    /// returns an arbitrary contact for the transmitee
+    /// a modeler in the future may institute a more complex contact model
+    /// setting weights by contact setting or shared household or the like in this method
+    fn get_contact(&mut self, transmitee: PersonId) -> Result<Option<PersonId>, IxaError>;
+    /// samples a person from a list of people with a weight by person
+    /// does not check any characteristics about the people
+    /// this is a generic method that is really just used for help sampling the person id
+    /// it is exposed to the user to allow them to make arbitrary sampling decisions
+    fn sample_person_from_list(&mut self, list: Vec<PersonId>, weights: &[f64])
+        -> Option<PersonId>;
+}
+
+impl QueryContacts for Context {
+    fn get_contact(&mut self, transmitee_id: PersonId) -> Result<Option<PersonId>, IxaError> {
+        if self.get_current_population() == 1 {
+            return Err(IxaError::IxaError(
+                "Cannot get a contact when there is only one person in the population.".to_string(),
+            ));
+        };
+        // get list of alive people
+        let alive_people = self.query_people((Alive, true));
+        if alive_people.len() > 1 {
+            // get a random person from the list of alive people
+            // assign weights to each person in the list
+            let mut weights = vec![1.0; alive_people.len()];
+            // get index of transmitee
+            let transmitee_index = alive_people
+                .iter()
+                .position(|&x| x == transmitee_id)
+                .unwrap();
+            // set this weight equal to 0 so we don't select the transmitee as the contact
+            weights[transmitee_index] = 0.0;
+            let contact_id = self.sample_person_from_list(alive_people, &weights);
+            Ok(contact_id)
+        } else {
+            // there are no contacts in the population -- the one remaining alive person must be the transmitee
+            // or there are no alive people in the population
+            Ok(None)
+        }
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    fn sample_person_from_list(
+        &mut self,
+        list: Vec<PersonId>,
+        weights: &[f64],
+    ) -> Option<PersonId> {
+        // subtract one because the weights are 1-indexed
+        let index = self.sample_distr(ContactRng, Categorical::new(weights).unwrap());
+        Some(list[index as usize])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::QueryContacts;
+    use crate::population_loader::Alive;
+    use ixa::{context::Context, people::ContextPeopleExt, random::ContextRandomExt};
+
+    #[test]
+    #[should_panic(
+        expected = "Cannot get a contact when there is only one person in the population."
+    )]
+    fn test_cant_get_contact_in_pop_of_one() {
+        let mut context = Context::new();
+        let transmitee = context.add_person(()).unwrap();
+        let _ = context.get_contact(transmitee).unwrap();
+    }
+
+    #[test]
+    fn test_return_none() {
+        let mut context = Context::new();
+        context.init_random(108);
+        let transmitee = context.add_person(()).unwrap();
+        let _ = context.add_person((Alive, false)).unwrap();
+        let observed_contact = context.get_contact(transmitee).unwrap();
+        assert!(observed_contact.is_none());
+    }
+
+    #[test]
+    fn test_return_remaining_alive_person() {
+        let mut context = Context::new();
+        context.init_random(108);
+        let transmitee = context.add_person(()).unwrap();
+        let _ = context.add_person((Alive, false)).unwrap();
+        let presumed_contact = context.add_person(()).unwrap();
+        let observed_contact = context.get_contact(transmitee).unwrap();
+        assert_eq!(observed_contact.unwrap(), presumed_contact);
+    }
+}

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -26,8 +26,10 @@ pub trait ContextContactExt {
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_sign_loss)]
 fn sample_person_from_list(context: &mut Context, list: &[PersonId], weights: &[f64]) -> PersonId {
-    let index = context.sample_distr(ContactRng, Categorical::new(weights).unwrap());
-    list[index as usize]
+    let index = context
+        .sample_distr(ContactRng, Categorical::new(weights).unwrap())
+        .floor() as usize;
+    list[index]
 }
 
 impl ContextContactExt for Context {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -40,7 +40,7 @@ impl ContextContactExt for Context {
                 .iter()
                 .position(|&x| x == transmitter_id)
                 .unwrap();
-            alive_people.remove(transmitter_index);
+            alive_people.swap_remove(transmitter_index);
 
             // In the future, we might like to sample people from the list by weights according
             // to some contact matrix. We would use sample_weighted instead.

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -11,64 +11,60 @@ use crate::population_loader::Alive;
 
 define_rng!(ContactRng);
 
-pub trait QueryContacts {
-    /// returns an arbitrary contact for the transmitee
-    /// a modeler in the future may institute a more complex contact model
-    /// setting weights by contact setting or shared household or the like in this method
-    fn get_contact(&mut self, transmitee: PersonId) -> Result<Option<PersonId>, IxaError>;
-    /// samples a person from a list of people with a weight by person
-    /// does not check any characteristics about the people
-    /// this is a generic method that is really just used for help sampling the person id
-    /// it is exposed to the user to allow them to make arbitrary sampling decisions
-    fn sample_person_from_list(&mut self, list: Vec<PersonId>, weights: &[f64])
-        -> Option<PersonId>;
+pub trait ContextContactExt {
+    /// Returns a potential contact for the transmitter.
+    /// Returns Ok(None) if there are no eligible contacts.
+    /// In the future, this function can be expanded to return a
+    /// contact specific to the person's household or to weight
+    /// drawing contacts be a contact matrix.
+    ///
+    /// Errors
+    /// - If there is only one person in the population.
+    fn get_contact(&mut self, transmitter_id: PersonId) -> Result<Option<PersonId>, IxaError>;
 }
 
-impl QueryContacts for Context {
-    fn get_contact(&mut self, transmitee_id: PersonId) -> Result<Option<PersonId>, IxaError> {
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+fn sample_person_from_list(context: &mut Context, list: &[PersonId], weights: &[f64]) -> PersonId {
+    let index = context.sample_distr(ContactRng, Categorical::new(weights).unwrap());
+    list[index as usize]
+}
+
+impl ContextContactExt for Context {
+    fn get_contact(&mut self, transmitter_id: PersonId) -> Result<Option<PersonId>, IxaError> {
         if self.get_current_population() == 1 {
             return Err(IxaError::IxaError(
                 "Cannot get a contact when there is only one person in the population.".to_string(),
             ));
         };
-        // get list of alive people
-        let alive_people = self.query_people((Alive, true));
+        // Get list of alive people (for now). May be expanded in the future to instead be
+        // list of alive people in the transmitter's contact setting or household.
+        // We will sample a random person from this list.
+        let mut alive_people = self.query_people((Alive, true));
         if alive_people.len() > 1 {
-            // get a random person from the list of alive people
-            // assign weights to each person in the list
+            // In the future, we might like to sample people from the list by weights according
+            // to some contact matrix.
             let mut weights = vec![1.0; alive_people.len()];
-            // get index of transmitee
-            let transmitee_index = alive_people
+            // Get the index of the transmitter.
+            let transmitter_index = alive_people
                 .iter()
-                .position(|&x| x == transmitee_id)
+                .position(|&x| x == transmitter_id)
                 .unwrap();
-            // set this weight equal to 0 so we don't select the transmitee as the contact
-            weights[transmitee_index] = 0.0;
-            let contact_id = self.sample_person_from_list(alive_people, &weights);
-            Ok(contact_id)
+            // Remove the transmitter from the list of contacts.
+            alive_people.remove(transmitter_index);
+            weights.remove(transmitter_index);
+            let contact_id = sample_person_from_list(self, &alive_people, &weights);
+            Ok(Some(contact_id))
         } else {
-            // there are no contacts in the population -- the one remaining alive person must be the transmitee
-            // or there are no alive people in the population
+            // This means that there are no eligible contacts in the population besides the transmitter.
             Ok(None)
         }
-    }
-
-    #[allow(clippy::cast_possible_truncation)]
-    #[allow(clippy::cast_sign_loss)]
-    fn sample_person_from_list(
-        &mut self,
-        list: Vec<PersonId>,
-        weights: &[f64],
-    ) -> Option<PersonId> {
-        // subtract one because the weights are 1-indexed
-        let index = self.sample_distr(ContactRng, Categorical::new(weights).unwrap());
-        Some(list[index as usize])
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::QueryContacts;
+    use super::ContextContactExt;
     use crate::population_loader::Alive;
     use ixa::{context::Context, people::ContextPeopleExt, random::ContextRandomExt};
 
@@ -78,17 +74,17 @@ mod test {
     )]
     fn test_cant_get_contact_in_pop_of_one() {
         let mut context = Context::new();
-        let transmitee = context.add_person(()).unwrap();
-        let _ = context.get_contact(transmitee).unwrap();
+        let transmitter = context.add_person(()).unwrap();
+        let _ = context.get_contact(transmitter).unwrap();
     }
 
     #[test]
     fn test_return_none() {
         let mut context = Context::new();
         context.init_random(108);
-        let transmitee = context.add_person(()).unwrap();
+        let transmitter = context.add_person(()).unwrap();
         let _ = context.add_person((Alive, false)).unwrap();
-        let observed_contact = context.get_contact(transmitee).unwrap();
+        let observed_contact = context.get_contact(transmitter).unwrap();
         assert!(observed_contact.is_none());
     }
 
@@ -96,10 +92,10 @@ mod test {
     fn test_return_remaining_alive_person() {
         let mut context = Context::new();
         context.init_random(108);
-        let transmitee = context.add_person(()).unwrap();
+        let transmitter = context.add_person(()).unwrap();
         let _ = context.add_person((Alive, false)).unwrap();
         let presumed_contact = context.add_person(()).unwrap();
-        let observed_contact = context.get_contact(transmitee).unwrap();
+        let observed_contact = context.get_contact(transmitter).unwrap();
         assert_eq!(observed_contact.unwrap(), presumed_contact);
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -39,8 +39,8 @@ impl ContextContactExt for Context {
                 // In the future, we might like to sample people from the list by weights according
                 // to some contact matrix. We would use sample_weighted instead. We would calculate
                 // the weights _before_ the loop and then sample from the list of people like here.
-                let index = self.sample_range(ContactRng, 0..eligible_contacts.len());
-                contact_id = eligible_contacts[index];
+                contact_id =
+                    eligible_contacts[self.sample_range(ContactRng, 0..eligible_contacts.len())];
             }
             Ok(Some(contact_id))
         } else {
@@ -63,8 +63,8 @@ mod test {
         let e = context.get_contact(transmitter);
         match e {
             Err(IxaError::IxaError(msg)) => assert_eq!(msg, "Cannot get a contact when there is only one person in the population.".to_string()),
-            Err(ue) => panic!("Expected an error that there should be no contacts when only one person in the population. Instead got {:?}", ue.to_string()),
-            Ok(Some(contact)) => panic!("Expected an error. Instead, got {contact:?} as contact with no errors."),
+            Err(ue) => panic!("Expected an error that there should be no contacts when there is only one person in the population. Instead got {:?}", ue.to_string()),
+            Ok(Some(contact)) => panic!("Expected an error. Instead, got {contact:?} as valid contact."),
             Ok(None) => panic!("Expected an error. Instead, returned None, meaning that there are no valid contacts."),
         }
     }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -29,23 +29,20 @@ impl ContextContactExt for Context {
                 "Cannot get a contact when there is only one person in the population.".to_string(),
             ));
         };
-        // Get list of alive people (for now). May be expanded in the future to instead be
-        // list of alive people in the transmitter's contact setting or household.
-        // We will sample a random person from this list.
-        let mut alive_people = self.query_people((Alive, true));
-        if alive_people.len() > 1 {
-            // Remove the transmitter from the list of contacts.
-            // Get the index of the transmitter.
-            let transmitter_index = alive_people
-                .iter()
-                .position(|&x| x == transmitter_id)
-                .unwrap();
-            alive_people.swap_remove(transmitter_index);
-
-            // In the future, we might like to sample people from the list by weights according
-            // to some contact matrix. We would use sample_weighted instead.
-            let index = self.sample_range(ContactRng, 0..alive_people.len());
-            Ok(Some(alive_people[index]))
+        // Get list of eligible people (for now, all alive people). May be expanded in the future
+        // to instead be list of alive people in the transmitter's contact setting or household.
+        // We sample a random person from this list.
+        let eligible_contacts = self.query_people((Alive, true));
+        if eligible_contacts.len() > 1 {
+            let mut contact_id = transmitter_id;
+            while contact_id == transmitter_id {
+                // In the future, we might like to sample people from the list by weights according
+                // to some contact matrix. We would use sample_weighted instead. We would calculate
+                // the weights _before_ the loop and then sample from the list of people like here.
+                let index = self.sample_range(ContactRng, 0..eligible_contacts.len());
+                contact_id = eligible_contacts[index];
+            }
+            Ok(Some(contact_id))
         } else {
             // This means that there are no eligible contacts in the population besides the transmitter.
             Ok(None)
@@ -57,16 +54,19 @@ impl ContextContactExt for Context {
 mod test {
     use super::ContextContactExt;
     use crate::population_loader::Alive;
-    use ixa::{context::Context, people::ContextPeopleExt, random::ContextRandomExt};
+    use ixa::{context::Context, people::ContextPeopleExt, random::ContextRandomExt, IxaError};
 
     #[test]
-    #[should_panic(
-        expected = "Cannot get a contact when there is only one person in the population."
-    )]
     fn test_cant_get_contact_in_pop_of_one() {
         let mut context = Context::new();
         let transmitter = context.add_person(()).unwrap();
-        let _ = context.get_contact(transmitter).unwrap();
+        let e = context.get_contact(transmitter);
+        match e {
+            Err(IxaError::IxaError(msg)) => assert_eq!(msg, "Cannot get a contact when there is only one person in the population.".to_string()),
+            Err(ue) => panic!("Expected an error that there should be no contacts when only one person in the population. Instead got {:?}", ue.to_string()),
+            Ok(Some(contact)) => panic!("Expected an error. Instead, got {contact:?} as contact with no errors."),
+            Ok(None) => panic!("Expected an error. Instead, returned None, meaning that there are no valid contacts."),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ use std::path::PathBuf;
 
 use crate::population_loader::{Age, CensusTract};
 
+use crate::parameters::Parameters;
+
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Args {
@@ -26,6 +28,12 @@ struct Args {
     #[arg(short, long, default_value = "false", default_missing_value = "true")]
     force_overwrite: bool,
 }
+
+mod periodic_report_population;
+mod contact;
+mod parameters;
+mod population_loader;
+mod transmission_manager;
 
 fn initialize(args: &Args) -> Result<Context, IxaError> {
     let mut context = Context::new();
@@ -55,6 +63,9 @@ fn initialize(args: &Args) -> Result<Context, IxaError> {
     population_loader::init(&mut context)?;
     context.index_property(Age);
     context.index_property(CensusTract);
+
+    // person-to-person transmission workflow
+    transmission_manager::init(&mut context);
 
     context.add_plan(parameters.max_time, |context| {
         context.shutdown();

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ struct Args {
     force_overwrite: bool,
 }
 
-mod periodic_report_population;
 mod contact;
+mod periodic_report_population;
 mod population_loader;
 mod transmission_manager;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn initialize(args: &Args) -> Result<Context, IxaError> {
     // Print out the parameters for debugging purposes for the user.
     println!("{parameters:?}");
 
-    // Return context for exectuion
+    // Return context for execution.
     Ok(context)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ struct Args {
 
 mod periodic_report_population;
 mod contact;
-mod parameters;
 mod population_loader;
 mod transmission_manager;
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -59,7 +59,7 @@ mod test {
                 assert_eq!(msg, "r_0 must be a non-negative number.".to_string());
             }
             Some(ue) => panic!(
-                "Unexpected an error that r_0 validation should fail. Instead got {:?}",
+                "Expected an error that r_0 validation should fail. Instead got {:?}",
                 ue.to_string()
             ),
             None => panic!("Expected an error. Instead, validation passed with no errors."),
@@ -81,7 +81,7 @@ mod test {
         let e = validate_inputs(&parameters).err();
         match e {
             Some(IxaError::IxaError(msg)) => assert_eq!(msg, "The generation interval must be positive.".to_string()),
-            Some(ue) => panic!("Unexpected an error that the generation interval validation should fail. Instead got {:?}", ue.to_string()),
+            Some(ue) => panic!("Expected an error that the generation interval validation should fail. Instead got {:?}", ue.to_string()),
             None => panic!("Expected an error. Instead, validation passed with no errors."),
         }
     }

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -1,0 +1,242 @@
+use ixa::{
+    context::Context,
+    define_person_property, define_person_property_with_default, define_rng,
+    error::IxaError,
+    global_properties::ContextGlobalPropertiesExt,
+    people::{ContextPeopleExt, PersonId, PersonPropertyChangeEvent},
+    random::ContextRandomExt,
+};
+use statrs::distribution::{ContinuousCDF, Exp, Poisson};
+
+use crate::contact::QueryContacts;
+use crate::parameters::Parameters;
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
+pub enum InfectiousStatus {
+    Susceptible,
+    Infectious,
+    Recovered,
+}
+
+define_rng!(TransmissionRng);
+
+define_person_property_with_default!(
+    InfectiousStatusType,
+    InfectiousStatus,
+    InfectiousStatus::Susceptible
+);
+
+fn evaluate_transmission(context: &mut Context, contact_id: PersonId, _transmittee_id: PersonId) {
+    // for now, we assume all transmission events are sucessful
+    // we have the contact_id as an argument to this fcn so that person-person pair transmission potential
+    // based on interventions can be evaluated to determine whether this transmission event is actually successful
+    if matches!(
+        context.get_person_property(contact_id, InfectiousStatusType),
+        InfectiousStatus::Susceptible
+    ) {
+        context.set_person_property(
+            contact_id,
+            InfectiousStatusType,
+            InfectiousStatus::Infectious,
+        );
+    }
+}
+
+fn infection_attempt(
+    context: &mut Context,
+    transmitee_id: PersonId,
+    gi: f64,
+    num_infection_attempts_remaining: f64,
+    next_infection_time_unif: f64,
+) -> Result<(), IxaError> {
+    // this is a method from a trait extention implemented in the contact manager
+    // we need to provide the transmitee id to ensure we do not just randomly sample that
+    // an agent infects themselves
+    // as long as this method returns a contact id, it can use any sampling strategy
+    // or logic to get there
+    let contact_id = context.get_contact(transmitee_id)?;
+    // evaluate transmission is its own function because there will be logic there eventually
+    // surrounding interventions
+    // if there are no contacts, to infect, do nothing
+    if let Some(contact_id) = contact_id {
+        evaluate_transmission(context, contact_id, transmitee_id);
+    }
+    // schedule the subsequent infection attempt for this infected agent,
+    // which happens at a greater value of the GI
+    if num_infection_attempts_remaining > 1.0 {
+        schedule_next_infection_attempt(
+            context,
+            transmitee_id,
+            gi,
+            num_infection_attempts_remaining - 1.0,
+            next_infection_time_unif,
+        );
+    }
+    // if no more infection attempts remaining, set the person to recovered
+    else {
+        context.set_person_property(
+            transmitee_id,
+            InfectiousStatusType,
+            InfectiousStatus::Recovered,
+        );
+    }
+    Ok(())
+}
+
+fn get_next_infection_time_unif(context: &mut Context, last_infection_time_unif: f64) -> f64 {
+    // this is NOT order statistics
+    // we are just playing around to make a point
+    // we will update the math to be correct later
+    context.sample_range(TransmissionRng, last_infection_time_unif..1.0)
+}
+
+fn get_next_infection_time_from_gi(
+    _context: &mut Context,
+    gi: f64,
+    next_infection_time_unif: f64,
+) -> f64 {
+    // this will be properly stored later
+    //let gi = context.get_data_container(generation_interval).unwrap();
+    // the math here is wrong as well -- we are not implementing order statistics
+    // there is no guarantee that these infection attempts are sequential draws from the GI distribution
+    // this will be fixed with real math later
+    Exp::new(1.0 / gi)
+        .unwrap()
+        .inverse_cdf(next_infection_time_unif)
+}
+
+fn schedule_next_infection_attempt(
+    context: &mut Context,
+    transmitee_id: PersonId,
+    gi: f64,
+    num_infection_attempts_remaining: f64,
+    last_infection_time_unif: f64,
+) {
+    // get next infection attempt time
+    let next_infection_time_unif = get_next_infection_time_unif(context, last_infection_time_unif);
+    let next_infection_time_gi =
+        get_next_infection_time_from_gi(context, gi, next_infection_time_unif);
+    // schedule the infection attempt: this grabs a contact at the time of the infection event
+    // to make sure the contacts are based on who is alive at that time and evaluates whether the
+    // transmission event is successful
+    context.add_plan(
+        context.get_current_time() + next_infection_time_gi,
+        move |context| {
+            infection_attempt(
+                context,
+                transmitee_id,
+                gi,
+                num_infection_attempts_remaining,
+                next_infection_time_unif,
+            )
+            .expect("Error finding contact in infection attempt");
+        },
+    );
+}
+
+fn handle_infectious_status_change(
+    context: &mut Context,
+    event: PersonPropertyChangeEvent<InfectiousStatusType>,
+    r_0: f64,
+    gi: f64,
+) {
+    // is the person going from S --> I?
+    // we don't care about the other cases here
+    if matches!(event.previous, InfectiousStatus::Susceptible) {
+        // get the number of infection attempts this person will have
+        // ok to use unwrap here because we pass inputs (r_0) through a validator
+        let num_infection_attempts =
+            context.sample_distr(TransmissionRng, Poisson::new(r_0).unwrap());
+        // start scheduling infection attempt events for this person
+        schedule_next_infection_attempt(context, event.person_id, gi, num_infection_attempts, 0.0);
+    }
+}
+
+pub fn init(context: &mut Context) {
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
+    context.subscribe_to_event(
+        move |context, event: PersonPropertyChangeEvent<InfectiousStatusType>| {
+            handle_infectious_status_change(
+                context,
+                event,
+                parameters.r_0,
+                parameters.generation_interval,
+            );
+        },
+    );
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ixa::{context::Context, people::PersonPropertyChangeEvent, random::ContextRandomExt};
+
+    #[test]
+    fn test_person_with_no_infection_attempts() {
+        let mut context = Context::new();
+        let person_id = context.add_person(()).unwrap();
+        let gi = 5.0;
+        let num_infection_attempts_remaining = 0.0;
+        let next_infection_time_unif = 0.5;
+
+        infection_attempt(
+            &mut context,
+            person_id,
+            gi,
+            num_infection_attempts_remaining,
+            next_infection_time_unif,
+        )
+        .unwrap();
+
+        assert_eq!(
+            context.get_person_property(person_id, InfectiousStatusType),
+            InfectiousStatus::Recovered
+        );
+    }
+
+    #[test]
+    fn test_transition() {
+        let mut context = Context::new();
+        let person_id = context.add_person(()).unwrap();
+        let gi = 5.0;
+        let num_infection_attempts_remaining = 3.0;
+        let next_infection_time_unif = 0.5;
+
+        infection_attempt(
+            &mut context,
+            person_id,
+            gi,
+            num_infection_attempts_remaining,
+            next_infection_time_unif,
+        )
+        .unwrap();
+
+        assert_eq!(
+            context.get_person_property(person_id, InfectiousStatusType),
+            InfectiousStatus::Infectious
+        );
+    }
+
+    #[test]
+    fn test_handle_infectious_status_change() {
+        let mut context = Context::new();
+        let person_id = context.add_person(()).unwrap();
+        let event = PersonPropertyChangeEvent {
+            person_id,
+            previous: InfectiousStatus::Susceptible,
+            current: InfectiousStatus::Infectious,
+        };
+        let r_0 = 2.0;
+        let gi = 5.0;
+
+        handle_infectious_status_change(&mut context, event, r_0, gi);
+
+        // Check if the person has scheduled infection attempts
+        let num_infection_attempts =
+            context.sample_distr(TransmissionRng, Poisson::new(r_0).unwrap());
+        assert!(num_infection_attempts > 0.0);
+    }
+}

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -228,7 +228,9 @@ mod test {
         };
         let mut context = Context::new();
         context.init_random(p_values.seed);
-        context.set_global_property_value(Parameters, p_values);
+        context
+            .set_global_property_value(Parameters, p_values)
+            .unwrap();
         context
     }
 

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -103,7 +103,7 @@ fn schedule_next_infection_attempt(
         );
         return;
     }
-    // Schedule the next infection attempt.
+
     // Get the next infection attempt time.
     let next_infection_times = get_next_infection_time(context, last_infection_time_uniform);
 

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -105,7 +105,8 @@ fn schedule_next_infection_attempt(
     }
 
     // Get the next infection attempt time.
-    let next_infection_times = get_next_infection_time(context, last_infection_time_uniform);
+    let (next_infection_time_unif, time_until_next_infection_attempt_gi) =
+        get_next_infection_time(context, last_infection_time_uniform);
 
     // Schedule the infection attempt. The function `infection_attempt` (a) grabs a contact at
     // the time of the infection event to ensure that the contacts are current and (b) evaluates
@@ -113,7 +114,7 @@ fn schedule_next_infection_attempt(
     // After that, schedule the next infection attempt for this infected agent with
     // one fewer infection attempt remaining.
     context.add_plan(
-        context.get_current_time() + next_infection_times.1,
+        context.get_current_time() + time_until_next_infection_attempt_gi,
         move |context| {
             infection_attempt(context, transmitter_id)
                 .expect("Error finding contact in infection attempt");
@@ -123,7 +124,7 @@ fn schedule_next_infection_attempt(
                 context,
                 transmitter_id,
                 num_infection_attempts_remaining - 1,
-                next_infection_times.0,
+                next_infection_time_unif,
             );
         },
     );

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -180,6 +180,17 @@ fn handle_infectious_status_change(
     }
 }
 
+/// This function seeds the initial infections in the population.
+fn seed_infections(context: &mut Context) {
+    // For now, we just pick a random person and make them infectious.
+    // In the future, we may pick people based on specific person properties.
+    context.set_person_property(
+        context.get_person_id(0),
+        InfectiousStatus,
+        InfectiousStatusType::Infectious,
+    );
+}
+
 pub fn init(context: &mut Context) {
     // Watch for changes in the InfectiousStatusType property.
     context.subscribe_to_event(
@@ -187,6 +198,9 @@ pub fn init(context: &mut Context) {
             handle_infectious_status_change(context, event);
         },
     );
+    context.add_plan(0.0, |context| {
+        seed_infections(context);
+    });
 }
 
 #[cfg(test)]

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -191,6 +191,8 @@ pub fn init(context: &mut Context) {
 
 #[cfg(test)]
 mod test {
+    use std::path::PathBuf;
+
     use crate::{parameters::Parameters, parameters::ParametersValues, population_loader::Alive};
 
     use super::{infection_attempt, init, InfectiousStatus, InfectiousStatusType};
@@ -207,7 +209,8 @@ mod test {
             infection_duration: 0.1,
             generation_interval: 3.0,
             report_period: 1.0,
-            synth_population_file: ".".to_string(),
+            synth_population_file: PathBuf::from("."),
+            population_periodic_report: String::new(),
         };
         let mut context = Context::new();
         context.init_random(p_values.seed);

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -17,7 +17,7 @@ use crate::parameters::Parameters;
 // spends in the infectious compartment is determined entirely from their
 // number of infection attempts and draws from the generation interval.
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
-pub enum InfectiousStatus {
+pub enum InfectiousStatusType {
     Susceptible,
     Infectious,
     Recovered,
@@ -26,9 +26,9 @@ pub enum InfectiousStatus {
 define_rng!(TransmissionRng);
 
 define_person_property_with_default!(
-    InfectiousStatusType,
     InfectiousStatus,
-    InfectiousStatus::Susceptible
+    InfectiousStatusType,
+    InfectiousStatusType::Susceptible
 );
 
 /// This function evaluates whether a transmission event is successful based on the characteristics
@@ -38,77 +38,79 @@ define_person_property_with_default!(
 /// function. This will allow us to evaluate the success of a transmission event based on the properties of
 /// both the transmitter and the contact in the future.
 fn evaluate_transmission(context: &mut Context, contact_id: PersonId, _transmitter_id: PersonId) {
-    if context.get_person_property(contact_id, InfectiousStatusType)
-        == InfectiousStatus::Susceptible
+    if context.get_person_property(contact_id, InfectiousStatus)
+        == InfectiousStatusType::Susceptible
     {
         context.set_person_property(
             contact_id,
-            InfectiousStatusType,
-            InfectiousStatus::Infectious,
+            InfectiousStatus,
+            InfectiousStatusType::Infectious,
         );
     }
 }
 
+/// This function is called when an infected agent has an infection event scheduled.
+/// This function includes identifying a potential contact to infect, evaluating whether
+/// the transmission event is successful, and scheduling the next infection event.
 fn infection_attempt(
     context: &mut Context,
     transmitter_id: PersonId,
     num_infection_attempts_remaining: usize,
-    next_infection_time_unif: f64,
+    infection_time_uniform: f64,
 ) -> Result<(), IxaError> {
-    // Only attempt the infection if the person has infection attempts remaining.
-    if num_infection_attempts_remaining > 0 {
-        // This is a method from a trait extension implemented in `mod contact`.
-        // As long as the method returns a contact id, it can use any underlying sampling strategy
-        // to obtain that contact, and that strategy can be separately implemented in `mod contact`
-        // without changing the logic here.
-        let contact_id = context.get_contact(transmitter_id)?;
+    // This is a method from a trait extension implemented in `mod contact`.
+    // As long as the method returns a contact id, it can use any underlying sampling strategy
+    // to obtain that contact, and that strategy can be separately implemented in `mod contact`
+    // without changing the logic here.
+    let contact_id = context.get_contact(transmitter_id)?;
 
-        // If there are no contacts to infect, do nothing.
-        if let Some(contact_id) = contact_id {
-            // We evaluate transmission in its own function because there will be eventually
-            // be intervention-based logic that determines whether a transmission event is successful.
-            evaluate_transmission(context, contact_id, transmitter_id);
-        }
+    // If there are no contacts to infect, do nothing.
+    if let Some(contact_id) = contact_id {
+        // We evaluate transmission in its own function because there will be eventually
+        // be intervention-based logic that determines whether a transmission event is successful.
+        evaluate_transmission(context, contact_id, transmitter_id);
+    }
 
-        // Schedule the next infection attempt for this infected agent.
-        schedule_next_infection_attempt(
-            context,
-            transmitter_id,
-            num_infection_attempts_remaining - 1,
-            next_infection_time_unif,
-        );
-    }
-    // If there are no more infection attempts remaining, set the person to recovered.
-    else {
-        context.set_person_property(
-            transmitter_id,
-            InfectiousStatusType,
-            InfectiousStatus::Recovered,
-        );
-    }
+    // Schedule the next infection attempt for this infected agent.
+    schedule_next_infection_attempt(
+        context,
+        transmitter_id,
+        num_infection_attempts_remaining - 1,
+        infection_time_uniform,
+    );
     Ok(())
 }
 
-/// Get the next infection time by sampling from a uniform distribution.
-fn get_next_infection_time_unif(context: &mut Context, last_infection_time_unif: f64) -> f64 {
-    // FOR NOW, we are using placeholder math to guarantee the infection times are always increasing.
-    // This is not order statistics. This will be corrected at a later time.
-    context.sample_range(TransmissionRng, last_infection_time_unif..1.0)
+struct InfectionTimes {
+    uniform: f64,
+    gi: f64,
 }
 
-/// Calculate the infection time corresponding to a uniform random number by passing
-/// through the inverse CDF of the generation interval (i.e., inverse transform
-/// sampling).
-fn get_next_infection_time_from_gi(context: &mut Context, next_infection_time_unif: f64) -> f64 {
+/// Calculate the next infection time. Draws an increasing value of a uniform distribution
+/// and passes it through the inverse CDF of the generation interval to get the next infection time.
+fn get_next_infection_time(
+    context: &mut Context,
+    last_infection_time_uniform: f64,
+) -> InfectionTimes {
+    // FOR NOW, we are using placeholder math to guarantee the infection times are always increasing.
+    // This is not order statistics. This will be corrected at a later time.
+    let next_infection_time_unif =
+        context.sample_range(TransmissionRng, last_infection_time_uniform..1.0);
+
     // In the future, we will generalize the use of an exponential distribution to
     // an arbitrary distribution with a defined inverse CDF.
     let gi = context
         .get_global_property_value(Parameters)
         .unwrap()
         .generation_interval;
-    Exp::new(1.0 / gi)
+    let next_infection_time_gi = Exp::new(1.0 / gi)
         .unwrap()
-        .inverse_cdf(next_infection_time_unif)
+        .inverse_cdf(next_infection_time_unif);
+
+    InfectionTimes {
+        uniform: next_infection_time_unif,
+        gi: next_infection_time_gi,
+    }
 }
 
 /// Schedule the next infection attempt for the transmitter based on the generation
@@ -117,40 +119,47 @@ fn schedule_next_infection_attempt(
     context: &mut Context,
     transmitter_id: PersonId,
     num_infection_attempts_remaining: usize,
-    last_infection_time_unif: f64,
+    last_infection_time_uniform: f64,
 ) {
-    // Get the next infection attempt time.
-    let next_infection_time_unif = get_next_infection_time_unif(context, last_infection_time_unif);
-    let next_infection_time_gi = get_next_infection_time_from_gi(context, next_infection_time_unif);
+    // If there are no more infection attempts remaining, set the person to recovered.
+    if num_infection_attempts_remaining == 0 {
+        context.set_person_property(
+            transmitter_id,
+            InfectiousStatus,
+            InfectiousStatusType::Recovered,
+        );
+    } else {
+        // Schedule the next infection attempt.
+        // Get the next infection attempt time.
+        let next_infection_times = get_next_infection_time(context, last_infection_time_uniform);
 
-    // Schedule the infection attempt. This function (a) grabs a contact at the time of the infection event
-    // to ensure that the contacts are current and (b) evaluates whether the transmission event is successful.
-    context.add_plan(
-        context.get_current_time() + next_infection_time_gi,
-        move |context| {
-            infection_attempt(
-                context,
-                transmitter_id,
-                num_infection_attempts_remaining,
-                next_infection_time_unif,
-            )
-            .expect("Error finding contact in infection attempt");
-        },
-    );
+        // Schedule the infection attempt. This function (a) grabs a contact at the time of the infection event
+        // to ensure that the contacts are current and (b) evaluates whether the transmission event is successful.
+        context.add_plan(
+            context.get_current_time() + next_infection_times.gi,
+            move |context| {
+                infection_attempt(
+                    context,
+                    transmitter_id,
+                    num_infection_attempts_remaining,
+                    next_infection_times.uniform,
+                )
+                .expect("Error finding contact in infection attempt");
+            },
+        );
+    }
 }
 
 #[allow(clippy::cast_possible_truncation)]
 #[allow(clippy::cast_sign_loss)]
 fn handle_infectious_status_change(
     context: &mut Context,
-    event: PersonPropertyChangeEvent<InfectiousStatusType>,
+    event: PersonPropertyChangeEvent<InfectiousStatus>,
 ) {
     // Is the person going from S --> I?
     // We don't care about the other transitions here, but this function will still be triggered
     // because it watches for any change in InfectiousStatusType.
-    if event.previous == InfectiousStatus::Susceptible {
-        // Person should currently be infectious.
-        assert_eq!(event.current, InfectiousStatus::Infectious);
+    if event.current == InfectiousStatusType::Infectious {
         // Get the number of infection attempts this person will have.
         let r_0 = context.get_global_property_value(Parameters).unwrap().r_0;
         let num_infection_attempts =
@@ -160,14 +169,21 @@ fn handle_infectious_status_change(
         // People who have num_infection_attempts = 0 are still passed through this
         // logic but don't infect anyone. This is so that so that there is only one
         // place where we need to handle setting people to recovered.
-        schedule_next_infection_attempt(context, event.person_id, num_infection_attempts, 0.0);
+        schedule_next_infection_attempt(
+            context,
+            event.person_id,
+            num_infection_attempts,
+            // last_infection_time_uniform is relative to when the agent became infectious.
+            // Basically, it details the fraction of the agent's infectiousness that has passed.
+            0.0,
+        );
     }
 }
 
 pub fn init(context: &mut Context) {
     // Watch for changes in the InfectiousStatusType property.
     context.subscribe_to_event(
-        move |context, event: PersonPropertyChangeEvent<InfectiousStatusType>| {
+        move |context, event: PersonPropertyChangeEvent<InfectiousStatus>| {
             handle_infectious_status_change(context, event);
         },
     );
@@ -210,14 +226,14 @@ mod test {
 
         context.set_person_property(
             person_id,
-            InfectiousStatusType,
-            InfectiousStatus::Infectious,
+            InfectiousStatus,
+            InfectiousStatusType::Infectious,
         );
         context.execute();
 
         assert_eq!(
-            context.get_person_property(person_id, InfectiousStatusType),
-            InfectiousStatus::Recovered
+            context.get_person_property(person_id, InfectiousStatus),
+            InfectiousStatusType::Recovered
         );
     }
 
@@ -234,8 +250,8 @@ mod test {
         // Set person to infectious, triggering the event watcher set up in the init function.
         context.set_person_property(
             person_id,
-            InfectiousStatusType,
-            InfectiousStatus::Infectious,
+            InfectiousStatus,
+            InfectiousStatusType::Infectious,
         );
 
         // Execute the model logic.
@@ -244,17 +260,18 @@ mod test {
         // Check that the transmitter is now recovered.
         assert!(context.get_current_time() > 0.0);
         assert_eq!(
-            context.get_person_property(person_id, InfectiousStatusType),
-            InfectiousStatus::Recovered
+            context.get_person_property(person_id, InfectiousStatus),
+            InfectiousStatusType::Recovered
         );
 
         // Check that their contact is also recovered.
         assert_eq!(
-            context.get_person_property(contact, InfectiousStatusType),
-            InfectiousStatus::Recovered
+            context.get_person_property(contact, InfectiousStatus),
+            InfectiousStatusType::Recovered
         );
     }
 
+    #[allow(clippy::cast_precision_loss)]
     fn variable_number_of_infection_attempts(n_attempts: usize, n_iter: i32) {
         // Using some math, we can test that the observed time of the end of the simulation
         // is what we expect it to be given the number of infection attempts.
@@ -264,7 +281,7 @@ mod test {
 
         let mut sum_end_times = 0.0;
         // In this test, e value of r_0 used to set up context is meaningless because we manually
-        // set the number of infection attempts.
+        // set the number of infection attempts below.
         let context = setup(1.0);
         let params = context
             .get_global_property_value(Parameters)
@@ -277,21 +294,33 @@ mod test {
             // Create a person who will be the only contact, but have them be dead so they can't be infected.
             // Instead, `get_contact` will return None.
             let only_contact = context.add_person((Alive, false)).unwrap();
-            infection_attempt(&mut context, transmitter_id, n_attempts, 0.0).unwrap();
+            // Since we call infection_attempt directly, we need to add one to n_attempts. Concretely,
+            // infection_attempt finds a contact and conducts an infection immediately, not scheduling a plan to do so.
+            // Instead, the next infection attempt is scheduled on a plan. Since the goal of this test is to evaluate
+            // the timing of when infection events occur, to test the timing of n_attempts infection events, we need to
+            // call infection_attempt n_attempts + 1 times.
+            infection_attempt(&mut context, transmitter_id, n_attempts + 1, 0.0).unwrap();
             context.execute();
             sum_end_times += context.get_current_time();
             assert_eq!(
-                context.get_person_property(transmitter_id, InfectiousStatusType),
-                InfectiousStatus::Recovered
+                context.get_person_property(transmitter_id, InfectiousStatus),
+                InfectiousStatusType::Recovered
             );
             assert_eq!(
-                context.get_person_property(only_contact, InfectiousStatusType),
-                InfectiousStatus::Susceptible
+                context.get_person_property(only_contact, InfectiousStatus),
+                InfectiousStatusType::Susceptible
             );
         }
-        // TODO(kzs9): figure out way to check math for n_attempts > 1
+
+        // Expected time elapsed comes from the memorylessness of the exponential distribution.
         let expected_time_elapsed =
-            f64::powi(params.generation_interval, n_attempts.try_into().unwrap());
+            params.generation_interval * (n_attempts as f64) * ((n_attempts as f64) + 1.0) / 2.0;
+
+        println!(
+            "Expected time elapsed: {}, Observed time elapsed: {}",
+            expected_time_elapsed,
+            sum_end_times / f64::from(n_iter)
+        );
 
         assert!(((sum_end_times / f64::from(n_iter)) - expected_time_elapsed).abs() < 0.1);
     }
@@ -299,5 +328,7 @@ mod test {
     #[test]
     fn test_variable_number_of_infection_attempts() {
         variable_number_of_infection_attempts(1, 1000);
+        variable_number_of_infection_attempts(2, 1000);
+        variable_number_of_infection_attempts(3, 5000);
     }
 }


### PR DESCRIPTION
## Description 

This PR implements a skeleton of the transmission model described in `docs/transmission.md`. The focus is not on getting the math right but rather the workflow of how we want to write our transmission model.

## Changes
This implements a simple way to get contacts (with test) and a simple person-to-person transmission based on some generation interval.

## Checklist
- What do you think of the general structuring of functions?
- Places where more test coverage is necessary?
- The overall logic/flow?