### PR TITLE
Update ixa - Closes issue #28

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,4 +19,4 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run main example
-      run: cargo run -- --input-file input/input.json  --output-directory output
+      run: cargo run -- -c input/input.json -o output

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This project presents a general transmission model developed in [ixa](https://github.com/CDCgov/ixa), the Center for Forecasting and Outbreak Analytics' agent-based modeling framework. The transmission model goal is to possess time-varying infectioussness, immunity, interventions, and multiple co-circulating pathogens.
 
 ## How to run the model
-As of 11/29/24, `cargo run -- -i ./input/input.json -o ./output`. There is an optional `-f` or `--force-overwrite` flag that can be
+As of 11/29/24, `cargo run -- -c ./input/input.json -o ./output`. There is an optional `-f` or `--force-overwrite` flag that can be
 passed to force overwriting of reports while in development/testing modes.
 
 ## Project Admin

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,9 +1,9 @@
 use ixa::{
-    context::Context,
+    Context,
     define_rng,
-    error::IxaError,
-    people::{ContextPeopleExt, PersonId},
-    random::ContextRandomExt,
+    IxaError,
+    ContextPeopleExt, PersonId,
+    ContextRandomExt,
 };
 
 use crate::population_loader::Alive;
@@ -54,7 +54,7 @@ impl ContextContactExt for Context {
 mod test {
     use super::ContextContactExt;
     use crate::population_loader::Alive;
-    use ixa::{context::Context, people::ContextPeopleExt, random::ContextRandomExt, IxaError};
+    use ixa::{Context, ContextPeopleExt, ContextRandomExt, IxaError};
 
     #[test]
     fn test_cant_get_contact_in_pop_of_one() {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,10 +1,4 @@
-use ixa::{
-    Context,
-    define_rng,
-    IxaError,
-    ContextPeopleExt, PersonId,
-    ContextRandomExt,
-};
+use ixa::{define_rng, Context, ContextPeopleExt, ContextRandomExt, IxaError, PersonId};
 
 use crate::population_loader::Alive;
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,4 +1,4 @@
-use ixa::{define_rng, Context, ContextPeopleExt, ContextRandomExt, IxaError, PersonId};
+use ixa::{define_rng, Context, ContextPeopleExt, IxaError, PersonId};
 
 use crate::population_loader::Alive;
 
@@ -26,15 +26,13 @@ impl ContextContactExt for Context {
         // Get list of eligible people (for now, all alive people). May be expanded in the future
         // to instead be list of alive people in the transmitter's contact setting or household.
         // We sample a random person from this list.
-        let eligible_contacts = self.query_people((Alive, true));
-        if eligible_contacts.len() > 1 {
+        if self.query_people((Alive, true)).len() > 1 {
             let mut contact_id = transmitter_id;
             while contact_id == transmitter_id {
                 // In the future, we might like to sample people from the list by weights according
                 // to some contact matrix. We would use sample_weighted instead. We would calculate
                 // the weights _before_ the loop and then sample from the list of people like here.
-                contact_id =
-                    eligible_contacts[self.sample_range(ContactRng, 0..eligible_contacts.len())];
+                contact_id = self.sample_person(ContactRng, (Alive, true))?;
             }
             Ok(Some(contact_id))
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,14 +17,13 @@ use crate::population_loader::{Age, CensusTract};
 
 #[derive(Args, Debug)]
 struct CustomArgs {
-    /// whether force overwrite of output files if they already exist
+    ///Whether force overwrite of output files if they already exist
     #[arg(short = 'f', long)]
     force_overwrite: bool,
 }
 
 fn initialize() -> Result<Context, IxaError> {
     let mut context = run_with_custom_args(|context, args, custom_args: Option<CustomArgs>| {
-        println!("Setting Overwrite parameter");
         // Read the global properties.
         let custom_args = custom_args.unwrap();
         // Set the output directory and whether to overwrite the existing file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,11 @@ mod parameters;
 mod population_loader;
 mod transmission_manager;
 
-use ixa::runner::run_with_custom_args;
 use clap::Args;
+use ixa::runner::run_with_custom_args;
 use ixa::{
-    Context, IxaError, ContextGlobalPropertiesExt,
-    ContextPeopleExt, ContextRandomExt, ContextReportExt,
+    Context, ContextGlobalPropertiesExt, ContextPeopleExt, ContextRandomExt, ContextReportExt,
+    IxaError,
 };
 use std::path::PathBuf;
 use transmission_manager::InfectiousStatus;
@@ -26,29 +26,21 @@ fn initialize() -> Result<Context, IxaError> {
     let mut context = run_with_custom_args(|context, args, custom_args: Option<CustomArgs>| {
         println!("Setting Overwrite parameter");
         // Read the global properties.
-        if let Some(custom_args)  = custom_args {            
-            // Set the output directory and whether to overwrite the existing file.
-            context
-                .report_options()
-                .directory(PathBuf::from(&args.output_dir))
-                .overwrite(custom_args.force_overwrite);
-        } else {
-            // If overwrite not specified, set to false (default)
-            context
-                .report_options()
-                .directory(PathBuf::from(&args.output_dir));
-        }
-        
+        let custom_args = custom_args.unwrap();
+        // Set the output directory and whether to overwrite the existing file.
+        context
+            .report_options()
+            .directory(PathBuf::from(&args.output_dir))
+            .overwrite(custom_args.force_overwrite);
         Ok(())
     })
     .unwrap();
 
-        
     let parameters = context
         .get_global_property_value(Parameters)
         .unwrap()
         .clone();
-        
+
     // Set the random seed.
     context.init_random(parameters.seed);
 
@@ -67,7 +59,7 @@ fn initialize() -> Result<Context, IxaError> {
     context.index_property(CensusTract);
 
     // Initialize the person-to-person transmission workflow.
-    transmission_manager::init(&mut context)?;
+    transmission_manager::init(&mut context);
 
     // Add a plan to shut down the simulation after `max_time`, regardless of
     // what else is happening in the model.

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-use ixa::{define_global_property, error::IxaError};
+use ixa::{define_global_property, IxaError};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -33,7 +33,7 @@ define_global_property!(Parameters, ParametersValues, validate_inputs);
 
 #[cfg(test)]
 mod test {
-    use ixa::error::IxaError;
+    use ixa::IxaError;
 
     use super::validate_inputs;
     use std::path::PathBuf;

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,8 +1,7 @@
 use crate::parameters::Parameters;
 use ixa::{
-    Context, define_person_property, define_person_property_with_default,
-    IxaError,
-    ContextGlobalPropertiesExt, ContextPeopleExt,
+    define_person_property, define_person_property_with_default, Context,
+    ContextGlobalPropertiesExt, ContextPeopleExt, IxaError,
 };
 
 use serde::Deserialize;

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,7 +1,8 @@
 use crate::parameters::Parameters;
 use ixa::{
-    context::Context, define_person_property, define_person_property_with_default, error::IxaError,
-    global_properties::ContextGlobalPropertiesExt, people::ContextPeopleExt,
+    Context, define_person_property, define_person_property_with_default,
+    IxaError,
+    ContextGlobalPropertiesExt, ContextPeopleExt,
 };
 
 use serde::Deserialize;
@@ -56,7 +57,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ixa::people::ContextPeopleExt;
+    use ixa::ContextPeopleExt;
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::NamedTempFile;

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -5,9 +5,11 @@ use ixa::{
 };
 use statrs::distribution::{ContinuousCDF, Exp, Poisson};
 
-use crate::contact::ContextContactExt;
-use crate::parameters::Parameters;
-use crate::population_loader::Alive;
+use crate::{
+    contact::ContextContactExt,
+    parameters::Parameters,
+    population_loader::Alive
+};
 
 // Define the possible infectious statuses for a person.
 // These states refer to the person's infectiousness at a given time

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -5,11 +5,7 @@ use ixa::{
 };
 use statrs::distribution::{ContinuousCDF, Exp, Poisson};
 
-use crate::{
-    contact::ContextContactExt,
-    parameters::Parameters,
-    population_loader::Alive
-};
+use crate::{contact::ContextContactExt, parameters::Parameters, population_loader::Alive};
 
 // Define the possible infectious statuses for a person.
 // These states refer to the person's infectiousness at a given time

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -7,6 +7,7 @@ use statrs::distribution::{ContinuousCDF, Exp, Poisson};
 
 use crate::contact::ContextContactExt;
 use crate::parameters::Parameters;
+use crate::population_loader::Alive;
 
 // Define the possible infectious statuses for a person.
 // These states refer to the person's infectiousness at a given time
@@ -46,7 +47,7 @@ pub fn init(context: &mut Context) {
 fn seed_infections(context: &mut Context) -> Result<(), IxaError> {
     // For now, we just pick a random person and make them infectious.
     // In the future, we may pick people based on specific person properties.
-    let random_person_id = context.sample_person(TransmissionRng)?;
+    let random_person_id = context.sample_person(TransmissionRng, (Alive, true))?;
     context.set_person_property(
         random_person_id,
         InfectiousStatus,

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -1,15 +1,12 @@
 use ixa::{
-    Context,
-    define_person_property, define_person_property_with_default, define_rng,
-    IxaError,
-    ContextGlobalPropertiesExt,
-    ContextPeopleExt, PersonId, PersonPropertyChangeEvent,
-    ContextRandomExt,
+    define_person_property, define_person_property_with_default, define_rng, Context,
+    ContextGlobalPropertiesExt, ContextPeopleExt, ContextRandomExt, IxaError, PersonId,
+    PersonPropertyChangeEvent,
 };
 use statrs::distribution::{ContinuousCDF, Exp, Poisson};
 
-use crate::parameters::Parameters;
 use crate::contact::ContextContactExt;
+use crate::parameters::Parameters;
 
 // Define the possible infectious statuses for a person.
 // These states refer to the person's infectiousness at a given time
@@ -33,7 +30,7 @@ define_person_property_with_default!(
 
 /// Seeds initial infections at t = 0, and subscribes to
 /// people becoming infectious to schedule their infection attempts.
-pub fn init(context: &mut Context) -> Result<(), IxaError> {
+pub fn init(context: &mut Context) {
     // Watch for changes in the InfectiousStatusType property.
     context.subscribe_to_event(
         move |context, event: PersonPropertyChangeEvent<InfectiousStatus>| {
@@ -43,7 +40,6 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
     context.add_plan(0.0, |context| {
         seed_infections(context).expect("Unable to seed infections");
     });
-    Ok(())
 }
 
 /// This function seeds the initial infections in the population.
@@ -228,8 +224,8 @@ mod test {
 
     use super::{init, InfectiousStatus, InfectiousStatusType};
     use ixa::{
-        Context, ContextGlobalPropertiesExt, ContextPeopleExt,
-        ContextRandomExt, PersonId, PersonPropertyChangeEvent,
+        Context, ContextGlobalPropertiesExt, ContextPeopleExt, ContextRandomExt, PersonId,
+        PersonPropertyChangeEvent,
     };
     use statrs::distribution::{ContinuousCDF, Exp};
 
@@ -257,7 +253,7 @@ mod test {
         // and we do not trigger the `get_contact` function -- which errors out in the case
         // of a population size of 1.
         let mut context = setup(0.000_000_000_000_000_01);
-        init(&mut context).expect("could not initialize");
+        init(&mut context);
         let person_id = context.add_person(()).unwrap();
 
         context.execute();
@@ -274,7 +270,7 @@ mod test {
         // zero secondary infections is extremely low.
         // This lets us check that the other person in the population is infected.
         let mut context = setup(50.0);
-        init(&mut context).expect("could not initialize");
+        init(&mut context);
         let person_id = context.add_person(()).unwrap();
         let contact = context.add_person(()).unwrap();
 
@@ -340,7 +336,7 @@ mod test {
             // By having only one person in the population when we choose the transmitter, we guarantee
             // that that one person is the transmitter. This lets us keep the transmitter id, which we
             // need below.
-            init(&mut context).expect("could not initialize");
+            init(&mut context);
             let infection_times_clone = Rc::clone(&infection_times);
             context.subscribe_to_event({
                 move |context, event: PersonPropertyChangeEvent<InfectiousStatus>| {

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -1,15 +1,15 @@
 use ixa::{
-    context::Context,
+    Context,
     define_person_property, define_person_property_with_default, define_rng,
-    error::IxaError,
-    global_properties::ContextGlobalPropertiesExt,
-    people::{ContextPeopleExt, PersonId, PersonPropertyChangeEvent},
-    random::ContextRandomExt,
+    IxaError,
+    ContextGlobalPropertiesExt,
+    ContextPeopleExt, PersonId, PersonPropertyChangeEvent,
+    ContextRandomExt,
 };
 use statrs::distribution::{ContinuousCDF, Exp, Poisson};
 
 use crate::parameters::Parameters;
-use crate::{contact::ContextContactExt, population_loader::Alive};
+use crate::contact::ContextContactExt;
 
 // Define the possible infectious statuses for a person.
 // These states refer to the person's infectiousness at a given time
@@ -31,9 +31,9 @@ define_person_property_with_default!(
     InfectiousStatusType::Susceptible
 );
 
-/// Seeds initial infections at t = 0, and subscribes to people becoming infectious
-/// to schedule their infection attempts.
-pub fn init(context: &mut Context) {
+/// Seeds initial infections at t = 0, and subscribes to
+/// people becoming infectious to schedule their infection attempts.
+pub fn init(context: &mut Context) -> Result<(), IxaError> {
     // Watch for changes in the InfectiousStatusType property.
     context.subscribe_to_event(
         move |context, event: PersonPropertyChangeEvent<InfectiousStatus>| {
@@ -41,21 +41,22 @@ pub fn init(context: &mut Context) {
         },
     );
     context.add_plan(0.0, |context| {
-        seed_infections(context);
+        seed_infections(context).expect("Unable to seed infections");
     });
+    Ok(())
 }
 
 /// This function seeds the initial infections in the population.
-fn seed_infections(context: &mut Context) {
+fn seed_infections(context: &mut Context) -> Result<(), IxaError> {
     // For now, we just pick a random person and make them infectious.
     // In the future, we may pick people based on specific person properties.
-    let alive_people = context.query_people((Alive, true));
-    let random_person_id = context.sample_range(TransmissionRng, 0..alive_people.len());
+    let random_person_id = context.sample_person(TransmissionRng)?;
     context.set_person_property(
-        alive_people[random_person_id],
+        random_person_id,
         InfectiousStatus,
         InfectiousStatusType::Infectious,
     );
+    Ok(())
 }
 
 // Called when a person's infectious status changes. Only considers people becoming infectious,
@@ -227,8 +228,8 @@ mod test {
 
     use super::{init, InfectiousStatus, InfectiousStatusType};
     use ixa::{
-        context::Context, global_properties::ContextGlobalPropertiesExt, people::ContextPeopleExt,
-        random::ContextRandomExt, PersonId, PersonPropertyChangeEvent,
+        Context, ContextGlobalPropertiesExt, ContextPeopleExt,
+        ContextRandomExt, PersonId, PersonPropertyChangeEvent,
     };
     use statrs::distribution::{ContinuousCDF, Exp};
 
@@ -256,7 +257,7 @@ mod test {
         // and we do not trigger the `get_contact` function -- which errors out in the case
         // of a population size of 1.
         let mut context = setup(0.000_000_000_000_000_01);
-        init(&mut context);
+        init(&mut context).expect("could not initialize");
         let person_id = context.add_person(()).unwrap();
 
         context.execute();
@@ -273,7 +274,7 @@ mod test {
         // zero secondary infections is extremely low.
         // This lets us check that the other person in the population is infected.
         let mut context = setup(50.0);
-        init(&mut context);
+        init(&mut context).expect("could not initialize");
         let person_id = context.add_person(()).unwrap();
         let contact = context.add_person(()).unwrap();
 
@@ -339,7 +340,7 @@ mod test {
             // By having only one person in the population when we choose the transmitter, we guarantee
             // that that one person is the transmitter. This lets us keep the transmitter id, which we
             // need below.
-            init(&mut context);
+            init(&mut context).expect("could not initialize");
             let infection_times_clone = Rc::clone(&infection_times);
             context.subscribe_to_event({
                 move |context, event: PersonPropertyChangeEvent<InfectiousStatus>| {


### PR DESCRIPTION
As described in issue #28, removed unnecessary module name in ixa imports, updated main to use ixa runner with custom args, and use `sample_person`. A couple of things to highlight:
1) sample_person does not yet allow to filter by a person property, so making a safe assumption here that everyone is alive at time t = 0.
2) It's a bit confusing to use custom_args for boolean values. For instance, I used the `force_overwrite` flag to determine whether or not to overwrite reports. If not specified, I would assume the value is false, but if not specified, `custom_args` would not exist, so I still need to do `if let Some(custom_args) = custom_args {}else{}`, which seems a bit unnecessasry. 