### PR TITLE
Proposing an API for specifying the natural history parameters

### DIFF
--- a/docs/0_contents.md
+++ b/docs/0_contents.md
@@ -3,10 +3,11 @@
 1. Synthetic population
 2. [Transmission](transmission.md)
     - [Time-varying infectiousness](time-varying-infectiousness.md)
-    - Estimating infectiousness from viral load
+    - [Storing and querying disease natural history](natural_history_manager.md)
 3. Contact
 4. Natural immunity
-5. Interventions
+5. Modeling CDC COVID-19 isolation guidance
     - Mask wearing
+    - Testing
     - Isolation
     - Vaccines

--- a/docs/0_contents.md
+++ b/docs/0_contents.md
@@ -2,7 +2,7 @@
 
 1. Synthetic population
 2. [Transmission](transmission.md)
-    - [Time-varying infectiousness](time-varying-infectiousness.md)
+    - [Time-varying infectiousness](time_varying_infectiousness.md)
     - [Storing and querying disease natural history](natural_history_manager.md)
 3. Contact
 4. Natural immunity

--- a/docs/natural_history_manager.md
+++ b/docs/natural_history_manager.md
@@ -278,7 +278,7 @@ a normalized hazard function which requires the same inputs, an absolute hazard 
 not require a separate distribution of $R_0$ because it quantifies _absolute_ hazard, etc.
 Regardless of the form of the generation interval, we use it to estimate the time to the next
 infection attempt. We implement the methods required to conduct this calculation in the trait
-`GenerationIntervalComputations` and we provide an implementation of this trait on the
+`GenerationIntervalComputations`, and we provide an implementation of this trait on the
 `GenerationInterval` type. Because there are multiple steps in this process, we define a method in
 the `ContextNaturalHistoryExt` called `time_to_next_infection_attempt` that conducts this routine
 according to our algorithm for calculating the

--- a/docs/natural_history_manager.md
+++ b/docs/natural_history_manager.md
@@ -410,7 +410,7 @@ type that also contained weighting information if their use case required that.
 This changes the type of the respiratory viral load natural history parameter to now be
 `Vec<TimeVaryingParameter>` and the type of the incubation period natural history parameter to be
 `Vec<ProbabilityDistribution>`. So far, we have implemented all the traits we need to compute
-quantites from the parameter values on the raw types, not vectors of the types. However, we want to
+quantities from the parameter values on the raw types, not vectors of the types. However, we want to
 modularly allow the user to modify their input file to have vectors of these types without needing
 to change the way their code is structured, so we implement these traits for the vectors of the
 types as well. Because the methods that use these types just require that they implement specific
@@ -422,7 +422,7 @@ Concretely, we implement the `Distribution` trait for `Vec<ProbabilityDistributi
 `Vec<GenerationInterval>`. This lets us change our parameter types to the vectored versions without
 changing their use in our code. These traits still do their computations on a particular instance of
 the underlying type in the vector (i.e., not the whole vector), so we introduce a new concept -- a
-erson property called the `NaturalHistoryIndex` that is of type `usize`. This index tells us which
+person property called the `NaturalHistoryIndex` that is of type `usize`. This index tells us which
 item in the vector to use as that person's particular value of a natural history parameter. That
 index value is used consistently across all natural history parameters for which a vector of values
 is specified, thereby allowing for paired/joint natural history parameter values. This also allows

--- a/docs/natural_history_manager.md
+++ b/docs/natural_history_manager.md
@@ -1,0 +1,219 @@
+# A central disease natural history manager
+
+## Overview
+
+The natural history manager holds the quantities that define an agent's infection. To achieve this,
+the manager provides a data plugin that stores infection-relevant parameter values and distributions
+and a trait extension for querying the modeling-relevant quantities derived from these parameters.
+Natural history parameters are defined broadly to include, for example, the number of secondary
+infection attempts by an infectious agent over their entire duration of infectiousness, the agent's
+relative probability of transmission over time/their generation interval distribution, and when they
+develop symptoms. The trait extension provides methods for querying quantities derived from these
+parameters relevant to parametrizing an infectious disease model, such as a method that returns the
+time to the next infection attempt calculated from the generation interval distribution (which the
+transmission manager calls when scheduling infection attempts). By using a trait extension to expose
+methods that other modules call, a user can modularly switch between natural history managers that
+make different assumptions about the relationship between natural history parameters and modeling-
+relevant quantities as long as the function signatures do not change.
+
+Here we describe the methods in the natural history trait extension -- including their function
+signatures and pseudocode -- and the format of an input CSV that specifies the natural history
+parameters. Ultimately, the most generic natural history manager randomly draws an agent's natural
+history parameters from an input CSV that contains samples of the natural history parameters,
+thereby not making assumptions about the underlying distribution of the parameters or their
+relationship to each other. However, if the user can make distributional assumptions about the
+natural history parameters, such as the generation interval being constant and the infectious period
+being exponentially-distributed, they could write their own natural history manager that encodes
+those distributions into their Rust code.
+
+## Trait extension methods
+
+### Querying transmission-relevant natural history parameters
+
+The natural history manager trait extension provides methods for querying interpretable modeling-
+relevant parameters. At the most basic level, the natural history trait extension must provide only
+one method: `time_to_next_infection_attempt`. This method uses the disease generation interval (GI)
+and [order statistics](./time-varying-infectiousness.md) to calculate the time to the next infection
+attempt. We adopt the convention that the method returns `None` if there are no more infection
+attempts, so the transmission manager only needs to call this one method to control the entire
+transmission workflow.
+
+Determining the time to the next infection attempt requires the following:
+1. Knowing the number of infection attempts remaining for this agent.
+2. Knowing the timing of their last infection attempt.
+3. Knowing the agent's disease generation interval distribution.
+4. Using order statistics to calculate the time to the next infection attempt based on the above
+quantities.
+
+When the `time_to_next_infection_attempt` method is called for the first time, it needs to set the
+agent's natural history parameters. For the `time_to_next_infection_attempt` method, the relevant
+parameters are the number of secondary infection attempts and generation interval distribution (or
+an index that can be used to query the generation interval and any other natural history parameters
+from an input CSV; more on this below). We set these parameters as person properties in the
+`assign_natural_history(&mut Context, PersonId)` function.
+
+```rust
+pub trait ContextNaturalHistoryExt {
+    fn time_to_next_infection_attempt(&mut self, person_id: PersonId) -> Option<f64> {
+        assign_natural_history(self, person_id);
+        let infection_attempts_remaining = self.get_person_property(person_id, NumInfectionAttemptsRemaining).unwrap();
+        if infection_attempts_remaining == 0 {
+            return None;
+        }
+        // Calculate the next infection attempt time.
+        // First, get the last infection attempt times.
+        let (last_infection_attempt_unif, last_infection_attempt_time) = self.get_person_property(person_id,
+                                                                                                  LastInfectionAttemptTime);
+        // Order statistics math to get the next infection attempt time.
+        let next_infection_attempt_unif = get_next_infection_attempt_unif(infection_attempts_remaining,
+                                                                          last_infection_attempt_unif);
+        // Convert from uniform space to real time.
+        // Takes the person id to query this person's assigned natural history parameter set.
+        let next_infection_attempt_time = next_infection_attempt_gi(next_infection_attempt_unif, person_id);
+        self.set_person_property(person_id, LastInfectionAttemptTime, (next_infection_attempt_unif, next_infection_attempt_time));
+        next_infection_attempt_time - last_infection_attempt_time
+    }
+}
+
+fn assign_natural_history(context: &mut Context, person_id: PersonId) {
+    if context.get_person_property(NaturalHistoryIndex).is_some() {
+        // Natural history index has already been set -- this is a repeat query of this function
+        // just to check that the natural history parameters have been set, so the parameters should
+        // not be reset. More on this below.
+        return;
+    }
+    context.set_person_property(NumInfectionAttemptsRemaining, Some(sample_infection_attempts(context, person_id)));
+    // LastInfectionAttemptTime is a tuple because it stores the last infection attempt time in both uniform
+    // and generation interval/real time space.
+    context.set_person_property(LastInfectionAttemptTime, (NotNan::new(0.0), NotNan::new(0.0)));
+    context.set_person_property(NaturalHistoryIndex, Some(sample_natural_history_parameter_sets(context, person_id)));
+}
+```
+
+### Querying clinical-relevant natural history parameters
+
+Most ABMs are calibrated to counts from clinical data, such as the number of people who are
+hospitalized or presenting with symptoms. This requires knowing what an agent's clinical disease
+manifestations are at a given time. The natural history trait extension provides methods to query an
+individual's time to symptom onset, improvement, hospitalization, or even symptoms experienced at a
+given time! By having one trait extension manage both transmission-relevant natural history
+parameters (ex., number of secondary infection attempts) and clinical-relevant natural history
+parameters (incubation period), we can allow for correlations between the two (for instance, that an
+agent's duration of symptoms and number of secondary infection attempts are positively related; more
+on this below).
+
+These methods also need to call `assign_natural_history()` to ensure that the natural history
+parameters relevant to these methods, namely the incubation period and time to symptom onset, are
+set. Since `assign_natural_history()` does not know its calling function, it should set all the
+natural history parameters (or an index that can be used to query them as mentioned above), and
+each natural history querying method should call it so to ensure that all natural history parameters
+are set. If, for example, the `time_to_symptom_onset` method below does not call the
+`assign_natural_history` method, that would require that the natural history had already been
+assigned and that the `time_to_next_infection_attempt` method had been called prior to the
+`time_to_symptom_onset` method. This would require that the transmission manager's event listeners
+were triggered prior to the clinical symptoms event manager's. That structure introduces subtle
+dependencies between modules, making them loss modular and prone to bugs.
+
+To ensure that an agent's natural history parameters are not being changed in the middle of their
+infection (i.e., a subsequent call to `assign_natural_history()` does not change the natural history
+parameters if they have already been set for this agent's infection), the method only sets the
+properties if they have not been set before. This choice allows for resetting the parameters prior
+to re-infection: in a future immunity manager, when an individual is returned to being susceptible,
+their `NaturalHistoryIndex` can be reset to `None`.
+
+```rust
+pub trait ContextNaturalHistoryExt {
+    fn time_to_symptom_onset(&mut self, person_id: PersonId) -> f64 {
+        // Assign natural history parameter set if they don't exist already.
+        assign_natural_history(self, person_id);
+        sample_incubation_time(self, person_id)
+    }
+    fn time_to_symptom_improvement(&mut self, person_id: PersonId) -> f64 {
+        // Assign natural history parameter set if they don't exist already.
+        assign_natural_history_idx(self, person_id);
+        sample_symptom_recovery_time(self, person_id)
+    }
+}
+```
+
+### Querying biomarker-relevant natural history parameters
+
+ABMs are often used to model the impact of disease testing programs where the probability of an
+individual testing positive is a function of their viral load. Therefore, it is necessary to have a
+method to query the viral load at a given time.
+
+```rust
+pub trait ContextNaturalHistoryExt {
+    fn viral_load(&mut self, person_id: PersonId, time: f64) -> f64 {
+        // Assign natural history parameter set if they don't exist already.
+        assign_natural_history(self, person_id);
+        sample_viral_load(person_id, time)
+    }
+}
+```
+
+## Input data
+
+The natural history manager must know the values and distributions of the natural history
+parameters. The most general natural history manager takes an input CSV of samples of the natural
+history parameters. The `sample_{parameter}` functions referenced above sample from the values in
+the CSV for a given parameter, assigning parameter indeces with a given `weight` and then sampling
+from the values present for the person's assigned natural history index at a given time.
+
+The input CSV is in long format and contains all the natural history parameters relevant to the
+model.
+
+| index | weight | time | parameter | value |
+| --- | --- | --- | --- | --- |
+| 0 | 0.45 | 0.0 | GenerationIntervalCDF | 0.0 |
+| 0 | 0.45 | 1.0 | GenerationIntervalCDF | 0.5 |
+| 0 | 0.45 | 2.0 | GenerationIntervalCDF | 1.0 |
+| 0 | 0.45 | NA | IncubationPeriod | 6 |
+| 0 | 0.45 | NA | TimeToSymptomImprovement | 7 |
+| 1 | 0.4 | 0.0 | GenerationIntervalCDF | 0.0 |
+| 1 | 0.4 | 1.0 | GenerationIntervalCDF | 0.8 |
+| 1 | 0.4 | 2.0 | GenerationIntervalCDF | 1.0 |
+| 2 | 0.15 | 0.0 | GenerationIntervalCDF | 0.1 |
+| ... | ... | ... | ... | ... |
+
+The `index` is a unique identifier that marks a distinct sample of the natural history parameters.
+Agents are assigned an index when infectious, and this is stored in the person property
+`NaturalHistoryIndex`. In this example, `index = 0` describes the infection of an individual who has
+a symptomatic infection because they have incubation period and time to symptom improvement values
+in their parameter set whereas `index = 1` describes the infection of an individual who is
+asymptomatic because symptom-associated parameters are not present in their natural history
+parameter set. This schema allows for describing different types of infections in a single input
+file. The `weight` column describes the weight with which to sample that particular infection
+archetype in the model. To add new parameters -- for instance, the viral load -- add a row (or rows
+if the parameter varies in time) for each `index` value for which this parameter is relevant to the
+input CSV.
+
+This input structure has two implications for time-varying parameters. First, there may be multiple
+parameters that vary over time, but they do not need to have values at the same time (for instance,
+the viral load and generation interval CDF for the same `index` could have samples at different
+time). Second, a time-varying parameter may have different time values across different `index`s.
+We use linear interpolation to estimate the value of a time-varying parameter at a continuous time
+value in the model from the samples provided at discrete times in the input CSV.
+
+## Application to isolation guidance
+
+To model isolation guidance at the community level, we need to:
+
+1. Read natural history parameters for symptomatic agents including the generation interval
+distribution, symptom onset time, symptom improvement time, and viral load over time.
+2. When an agent becomes infected, assign a natural history parameter set that consists of a
+generation interval, symptom onset time, symptom improvement time, and viral load. This parameter
+set should be a joint posterior sample from the Stan model, so that all parameters are related,
+meaning that the generation interval distribution is associated with particular values of the
+symptom onset time and improvement time.
+3. We tested different generation intervals in our isolation guidance modeling, so we should be able
+to easily swap between generation intervals in our ABM to examine how assumptions about
+infectiousness over time change our results.
+3. (For the current guidance) Label individuals as isolating while they are experiencing symptoms,
+and have their infectiousness and contacts changed accordingly. Label individuals as in
+post-isolation precautions for five days after their symptoms improve, and have their infectiousness
+and contacts changed accordingly.
+4. (For the previous guidance) Simulate individuals getting a COVID test when they first start
+experiencing symptoms with test positivity as a function of their viral load.
+
+The structure described in this natural history manager enables each of these requirements.

--- a/docs/natural_history_manager.md
+++ b/docs/natural_history_manager.md
@@ -18,7 +18,7 @@ Unlike most managers that provide a trait extension on `Context` with methods th
 call, this manager's main contribution is different natural history parameter types on which traits
 have been implemented that enable computing quantities relevant to modeling disease at the
 individual-level. This manager also provides a trait extension on `Context` called the
-`ContextNaturalHistoryExt` that contains convenience methods for common multistep calculations on
+`ContextNaturalHistoryExt` that contains convenience methods for common multi-step calculations on
 natural history parameters. The custom types defined in this module are all deserializable, so the
 user can specify natural history parameters in an input JSON file, taking advantage of the existing
 global properties plugin's infrastructure. We focus on having these types be as generic as possible,
@@ -43,6 +43,9 @@ pub enum ProbabilityDistribution {
 }
 ```
 
+We can also add a similar type called `ProbabilityDistributionDiscrete` that is the same but only
+for discrete distributions (`Poisson`, `NegBin`, `Empirical(Vec<usize>)`).
+
 A user may specify time-invariant natural history parameters in the input JSON as follows:
 
 ```json
@@ -57,31 +60,37 @@ A user may specify time-invariant natural history parameters in the input JSON a
 
 In the case of the distribution for $R_0$, we are saying that all agents have the same value of
 $R_0$ -- there is no stochasticity or person-to-person variation in $R_0$. Nevertheless, because we
-have defined the `Distribution` type broadly, we can consider this special case. For the type, we
-implement a getter method that returns a type that implements Rust's `statrs`'s `Distribution`
-trait. This enables us to draw random samples from the distribution and treat it like we natively
-defined the distribution type in Rust without going through our enum first. To reduce confusion, we
-adopt that the meaning of parameters in our custom `ProbabilityDistribution` type is the same as in
-the associated `statrs` type.
+have defined the `Distribution` type broadly, we can consider this special case. For our
+`ProbabilityDistribution` type, we implement Rust's `rand` crate's `Distribution` trait. This
+enables us to draw random samples from the distribution using Ixa's built-in `ContextRandomExt` that
+expects a type that implements `Distribution<T>` for sampling. This lets us treat our custom enum
+like we natively defined the distribution type in Rust without going through our enum first. To
+reduce confusion, we adopt that the meaning of parameters in our custom `ProbabilityDistribution`
+type is the same as in the `statrs` distribution of the same name.
 
 ```rs:natural_history_manager.rs
-use statrs::distribution::{Exp, Gamma, Empirical};
+use rand::distribution::Distribution
+use statrs::distribution::{Exp, Gamma, Empirical}
 
-impl ProbabilityDistribution {
-    pub fn get(&self) -> impl Distribution<f64> {
+impl Distribution<f64> for ProbabilityDistribution {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> f64 {
         match self {
-            ProbabilityDistribution::Exp(lambda) => Exp::new(lambda).unwrap(),
-            ProbabilityDistribution::Gamma(a, b) => Gamma::new(a, b).unwrap(),
-            ProbabilityDistribution::Empirical(vals) => Empirical::from_iter(vals).unwrap()
+            ProbabilityDistribution::Exp(lambda) => rng.sample(Exp::new(lambda).unwrap()),
+            ProbabilityDistribution::Gamma(a, b) => rng.sample(Gamma::new(a, b).unwrap()),
+            ProbabilityDistribution::Empirical(vals) => rng.sample(Empirical::from_iter(vals).unwrap())
         }
     }
 }
 ```
 
-If a user wanted to use this type to draw a random sample in a module, say to draw the time at which
-to set the person's health status to symptomatic once the agent becomes infected, and the incubation
-period distribution were specified in the input JSON file as described above, they would do the
-following:
+The user can also implement their own traits on the `ProbabilityDistribution` type if they needed
+to extract the raw `statrs` type (i.e., what they would have gotten if they called `Exp::new(1.0)`,
+for instance) or to do other computations like getting the mean or variance of the distribution.
+
+To draw a random sample in a module with this type, say to draw the time at which to set the
+person's health status to symptomatic once the agent becomes infected based on the incubation period
+(which we assume is specified in the input JSON file as described above and set as a global
+property), the user would do the following:
 
 ```rs:health_status_manager.rs
 fn handle_infectious_status_change(
@@ -95,7 +104,7 @@ fn handle_infectious_status_change(
             HealthStatusType::Presymptomatic);
 
         let incubation_per = context.get_global_property_value(Parameters).unwrap()
-                                .incubation_period.get()
+                                .incubation_period;
         let incubation_time = context.sample_distr(HealthStatusRng, incubation_per);
         context.add_plan(
             context.get_current_time() + incubation_time,
@@ -110,13 +119,14 @@ fn handle_infectious_status_change(
 }
 ```
 
-The modular structure lends itself to the user being able to easily change the underlying
-distribution type (i.e., switching out a gamma for, say, a lognormal) in the input JSON with no
-change to the code and only needing to make sure their new distribution can be coerced into a Rust
-type that implements the `Distribution` trait. Our `ProbabilityDistribution` type handles many cases
-of natural history parameters and more broadly being able to specify and sample from arbitrary
-distributions in our ABMs. This type also serves as the building block for the next natural history
-parameter type we define: time-varying parameters.
+The modular structure lends itself to being able to easily change the underlying distribution type
+(i.e., switching out a gamma for, say, a lognormal) in the input JSON with no change to the code and
+only needing to make sure the new distribution can be coerced into a Rust type that implements the
+`Distribution` trait. The incubation period parameters could even be updated in the middle of the
+simulation! Our `ProbabilityDistribution` type handles many use cases for natural history parameters
+and more broadly being able to specify and sample from arbitrary distributions in our ABMs. This
+type also serves as the building block for the next natural history parameter type we define:
+time-varying parameters.
 
 ### Time-varying parameters: An example from specifying the respiratory viral load
 
@@ -144,61 +154,138 @@ Concretely, a user may specify a time-varying parameter like so in their input J
 
 Because our custom `TimeVaryingParameter` type builds off our existing infrastructure for the
 `ProbabilityDistribution` type, we hold a more general idea of a time-varying parameter than is
-implemented in most ABMs: concretely, we argue that the value of a time-varying parameter at a given
-time may itself be a random distribution rather than being a fixed value. However, based on what we
-have introduced so far, this type does not allow for the user to specify viral load _trajectories_
-(i.e., one agent is assigned an entire set of deterministic viral loads and another agent has a
-different specified set). While a user could effectively hijack this current type to do that by
-implementing their own sampling method that provides the desired behavior, we devise a general
-solution to this problem below exploiting infrastructure we have to build to allow for correlated
-parameter values.
+generally implemented in most ABMs: concretely, we allow for the value of a time-varying parameter
+at a given time to itself be a random distribution rather than being a fixed value. However, based
+on what we have introduced so far, this type alone does not allow for the user to specify viral load
+_trajectories_ (i.e., one agent is assigned an entire set of deterministic viral loads and another
+agent has a different specified set). While a user could effectively hijack this current type to do
+that by implementing their own sampling method that provides the desired behavior, we devise a
+general solution to this problem below exploiting infrastructure we have to build to allow for
+correlated parameter values.
 
 With a time-varying parameter, we want a method to get the value of the parameter at a given time.
 This process requires more steps, so we define a convenience method in a trait extension on
-context that helps us do this.
-
-### Implementing new methods on subtypes: An example from using the disease generation interval
-
-
-
-## Allowing for correlation between parameter values
-
-
-
-
-
+`Context` that helps us do this. Because we will soon define other cases of time-varying parameters,
+we make these methods take any type that implement a trait we define called `LinearInterpolation`
+(described below).
 
 ```rs:natural_history_manager.rs
 pub trait ContextNaturalHistoryExt {
-    fn get_parameter_value(
+    fn estimate_parameter_at_value(
         &mut self,
-        person_id: PersonId,
-        parameter: NaturalHistoryParameter
-    ) -> impl NaturalHistoryParameterValue;
+        person: PersonId,
+        p: &impl LinearInterpolation,
+        value: f64) -> f64 {
+            self.estimate_parameter_at_time_greater(p, person, time, 0)
+        }
 
-    fn time_to_next_infection_attempt(&mut self, person_id: PersonId) -> Option<f64>;
-}
-
-pub trait NaturalHistoryParameterValue {
-    fn get_value(&self) -> f64;
-    fn estimate_at_point(&self, x: f64, invert: bool, start: f64) -> f64;
+    fn estimate_parameter_at_value_greater(
+        &mut self,
+        person: PersonId,
+        p: &impl LinearInterpolation,
+        value: f64,
+        last_index_used: usize) -> f64
 }
 ```
 
-We implement the `NaturalHistoryParameterValue` trait for the common return types of natural history
-parameter values (details below). At a high level, these methods provide the post-processing needed
-to use natural history parameter values in an individual-level model.
+We explain [below](#allowing-for-correlation-between-parameter-values) why we require the person as
+an argument and why we must take a mutable reference to `Context` -- in brief, this is so that we
+can allow for correlations between parameter values.
 
-### Querying transmission-relevant quantities
+At a high-level, this method finds the nearest times and indeces both less than and greater than the
+provided `time` from the time vector in the time-varying parameter (implemented as part of the
+`LinearInterpolation` trait), draws samples from the corresponding distributions at those times, and
+takes the weighted average of the sampled values on their time's distance to the given time. These
+implementation details are abstracted from the calling module. However, there is one implementation
+detail we expose to the user. In many cases, we estimate the value of a time-varying parameter at
+always increasing times (i.e., when we require an agent's viral load and their time since infection
+is always increasing). If we store the index of the last value at which the time-varying parameter
+was queried, we know that our current value of that parameter must be at a greater index. We can use
+this trick to speed up the process of searching for indeces.
 
-The natural history manager provides a method for querying the time to the next infection attempt
-called by the transmission manager. Since our
-[algorithm for calculating the time to the next infection attempt](./time_varying_infectiousness.md)
-relies on an individual's natural history parameters, we want the `time_to_next_infection_attempt`
-method to be in the `ContextNaturalHistoryExt` trait extension. This structure also simplifies the
-code in the transmission manager, improving modularity. Adopting the convention that the method
-returns `None` if there are no more infection attempts, the transmission manager would call the
-method as follows:
+There is a special case of a time-varying parameter: one that is invertible, meaning that we can
+instead run an estimation routine on the inverse of the parameter, such as estimating the time at
+which the viral load (or any other time-varying parameter) equals a given value (rather than
+estimating the viral load at a given time). While use cases for this type on its own are rare, it
+is critical for allowing different ways of specifying the generation interval (described in the
+[next section](#implementing-new-methods-on-subtypes-an-example-from-using-the-disease-generation-interval)).
+
+```rs:natural_history_manager.rs
+#[derive(Deserialize)]
+pub struct InvertibleTimeVaryingParameter (
+    pub Vec<f64>,
+    pub Vec<f64>
+)
+```
+
+For this type, we implement the `LinearInterpolation` trait that enables us to grab the indeces of
+the values that window a particular value, and we implement a method that returns the inverse tuple.
+
+```rs:natural_history_manager.rs
+impl InvertibleTimeVaryingParameter {
+    pub fn invert(&self) -> InvertibleTimeVaryingParameter {
+        InvertibleTimeVaryingParameter(self.1.clone(), self.0.clone())
+    }
+}
+```
+
+### Implementing new methods on subtypes: An example from using the disease generation interval
+
+One particular natural history parameter that is critical to almost all disease models and which
+requires in-depth manipulation to obtain values relevant to modeling disease at the individual-level
+is the disease generation interval. First, the generation interval can be specified in multiple
+ways: in a simple disease model, the user may want to simply say the generation interval follows
+a given distribution (exponential or gamma), allowing for direct recovery of a differential equation
+compartmental model. In more complicated models, the user may want to directly specify the
+generation interval as a set of values. We create an enum called `GenerationInterval` which contains
+different variants to represent the multiple ways a user may specify the generation interval.
+
+```rs:natural_history_manager.rs
+#[derive(Deserialize)]
+pub enum GenerationInterval {
+    Distribution(ProbabilityDistribution, ProbabilityDistribution),
+    LengthAndMagnitude(ProbabilityDistribution, ProbabilityDistribution, ProbabilityDistribution),
+    Cdf(InvertibleTimeVaryingParameter, ProbabilityDistribution),
+    NormalizedHazard(InvertibleTimeVaryingParameter, ProbabilityDistribution),
+    AbsoluteHazard(InvertibleTimeVaryingParameter)
+}
+```
+
+By convention, when modelers say "the generation interval is exponential", that means that the
+generation interval _length_ is exponential and the magnitude over time is constant. We adopt the
+same shorthand (the first enum variant listed above) and then a more complete option that allows the
+user to separately specify the length and magnitude separately (the second option). In both cases,
+the distribution for $R_0$ must also be specified, and that is the final parameter in each of these
+variants. By tethering these two parameters together, we are ensuring that if the variant value
+picked by the user requires a distribution for $R_0$, they actually must provide it otherwise the
+model will not compile. If we were to separately specify the $R_0$ distribution, we would have to
+check for the existence of that parameter (assuming a consistent name for it) when the model is
+validating its parameters, deferring the error to later and making assumptions about code structure.
+
+When the user cannot confine the generation interval to an analytical distribution (i.e., they have
+empirical samples of the distribution over time), we allow multiple ways to specify the generation
+interval -- as a CDF (requiring an invertible time varying parameter and a distribution of $R_0$),
+a normalized hazard function which requires the same inputs, an absolute hazard function which does
+not require a separate distribution of $R_0$ because it quantifies _absolute_ hazard, etc.
+Regardless of the form of the generation interval, we use the generation interval to estimate the
+time to the next infection attempt. Because there are multiple steps in this process, we define a
+method in the `ContextNaturalHistoryExt` called `time_to_next_infection_attempt` that conducts this
+routine according to our algorithm for calculating the
+[time to the next infection attempt](./time_varying_infectiousness.md).
+
+```rs:natural_history_manager.rs
+pub trait ContextNaturalHistoryExt {
+    fn time_to_next_infection_attempt(
+        &mut self,
+        gi: GenerationInterval,
+        person: PersonId) -> Option<f64>;
+}
+```
+
+We require the person because the time to the next infection attempt relies on person properties
+like the agent's last infection time, number of secondary infection attempts remaining, etc. We
+adopt the convention that the method returns `None` if there are no more infection attempts. The
+method would be used in the transmission manager as follows:
 
 ```rs:transmission_manager.rs
 fn handle_infectious_status_change(
@@ -216,7 +303,8 @@ fn schedule_next_infection_attempt(
     context: &mut Context,
     transmitter_id: PersonId,
    ) {
-    if let Some(delta_time) = context.time_to_next_infection_attempt(event.transmitter_id) {
+    let gi = context.get_global_property_value(Parameters).unwrap().generation_interval;
+    if let Some(delta_time) = context.time_to_next_infection_attempt(gi, event.transmitter_id) {
         context.add_plan(
             context.get_current_time() + delta_time,
             move |context| {
@@ -234,16 +322,39 @@ fn schedule_next_infection_attempt(
 
 By abstracting the computation for getting the next infection attempt time into the natural history
 manager, the transmission manager's syntax is focused entirely on the person-to-person transmission
-workflow, independent of the mathematical calculations to obtain the times. This helps improve
-modularity, even giving the user the option to use their own `time_to_next_infection_attempt` that
-uses a custom sampling strategy.
+workflow, independent of the mathematical calculations to obtain the times. This syntax points more
+clearly to what the transmission manager is actually doing and helps improve modularity between the
+mathematical details and the logic flow of the model. At a high level, our
+`time_to_next_infection_attempt` method uses [order statistics](./time_varying_infectiousness.md)
+to calculate the time to the next infection attempt. The method:
 
-We use the [order statistics](./time_varying_infectiousness.md) sampling strategy to calculate the
-time to the next infection attempt. This means that the `time_to_next_infection_attempt` method
-requires the following:
-1. The individual's disease generation interval,
-2. The number of secondary infection attempts remaining, and
-3. The time of the last infection attempt.
+1. Returns `None` if there are no infection attempts remaining.
+2. Draws the next ordered uniform value based on the number of infection attempts remaining.
+3. Estimates the time at which the next infection attempt occurs by passing the uniform value
+through the inverse CDF.
+
+Internally, this method keeps track of:
+1. The agent's remaining number of secondary infection attempts (or, if the absolute hazard function
+was specified, remaining absolute infectiousness). Because our structure for the generation interval
+is coupled to the number of secondary infection attempts, the calling code does not need to worry
+about this quantity, and all calculations -- which depend on the variant value -- are abstracted
+away from the transmission manager into the `time_to_next_infection_attempt` method.
+2. The time of the last infection attempt, both as a uniform number and in absolute space, which is
+kept track of as a person property. This also means that the `ContextNaturalHistoryExt` provides a
+convenience method for resetting these internal parameters at the end of an infection to allow for
+reinfection.
+
+```rs:natural_history_manager.rs
+pub trait ContextNaturalHistoryExt {
+    fn reset_to_susceptible(&mut self, person: PersonId);
+}
+```
+
+## Allowing for correlation between parameter values
+
+
+
+
 
 We discuss the details of querying an agent's natural history parameters below when introducing the
 format of the input CSV that contains these parameters. For now, know that the method
@@ -549,52 +660,7 @@ impl ContextNaturalHistoryExt for Context {
 `get_parameter_value()` requires a mutable reference to `Context` because it calls
 `assign_natural_history()`, which potentially sets a person property.
 
-## Input format for natural history parameters
 
-The natural history manager must know the values and distributions of the natural history
-parameters. The most general natural history manager takes an input CSV of samples of the natural
-history parameters. It reads in this CSV, stores it in the `NaturalHistory` data plugin, and then
-queries the relevant values for a given person on demand.
-
-We expect the input CSV to take on the following long format easily conducive to adding new natural
-history parameters:
-
-| index | weight | time | parameter | value |
-| --- | --- | --- | --- | --- |
-| 0 | 0.45 | 0.0 | GenerationIntervalCDF | 0.0 |
-| 0 | 0.45 | 1.0 | GenerationIntervalCDF | 0.5 |
-| 0 | 0.45 | 2.0 | GenerationIntervalCDF | 1.0 |
-| 0 | 0.45 | NA | IncubationPeriod | 6 |
-| 0 | 0.45 | NA | TimeToSymptomImprovement | 7 |
-| 1 | 0.4 | 0.0 | GenerationIntervalCDF | 0.0 |
-| 1 | 0.4 | 1.0 | GenerationIntervalCDF | 0.8 |
-| 1 | 0.4 | 2.0 | GenerationIntervalCDF | 1.0 |
-| 2 | 0.15 | 0.0 | GenerationIntervalCDF | 0.1 |
-| ... | ... | ... | ... | ... |
-
-This CSV contains the values of all natural history parameters that the natural history manager
-knows about. Parameters are specified by an index, the same index that an agent is assigned
-(proportional to the specified weight) when their natural history parameters are queried. Grouping
-parameters by indeces allows for implicit correlations and dependencies between parameters. For
-instance, in this example `index = 0` describes the infection of an individual who has a symptomatic
-infection because they have an incubation period and time to symptom improvement. Both are required
-to specify a symptomatic infection. Likewise, the generation interval CDF for this person can be
-specific to them being a symptomatic individual. Implicitly, all values of a parameter for a given
-index represent a joint sample from the data generation process for the natural history of
-infectious agents. On the other hand, the agent who is assigned `index = 1` has an asymptomatic
-infection because these parameters are not present in their parameter set. Therefore, this input
-schema allows for describing different types of infections in a single file. Simultaneously, the
-`weight` column allows for each of the different infection types to be sampled proportional to their
-occurrence in observational data (or even for this quantity to be calibrated). To add new parameters
--- for instance, the viral load -- add a row (or rows if the parameter varies in time) for each
-`index` value for which this parameter is relevant (i.e., infection type) to the input CSV.
-
-This input structure has two implications for time-varying parameters. First, there may be multiple
-parameters that vary over time, but they do not need to have values at the same time (for instance,
-the viral load and generation interval CDF for the same `index` could have samples at different
-time). Second, a time-varying parameter may have different time values across different `index`s.
-Despite this variety in types of inputs, all parameters can be stored and queried the same
-through the natural history manager and by using the `NaturalHistoryParameterValue` trait.
 
 ## Application to isolation guidance at the community level
 


### PR DESCRIPTION
Revamped version of #36 inspired by Jason and Guido's suggestions to think about toggling between transmission model "modes" and how we can make specifying simple disease models and complex custom models equally easy.

Once we have agreement on the API, I am happy to make small PRs with sketches of the code that implements the ideas presented here, but I want us to have agreement on the API first.