### PR TITLE
Update Github actions precommit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,6 +11,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/pre-commit
+          ~/.cache/R/renv
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: r-lib/actions/setup-r@v2
       with:
         use-public-rspm: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,11 @@ repos:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: package.lock.json
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+        args: ["--verbose", "--"]
+    -   id: clippy
+        # Use 'all-targets' to run on all code, including tests and examples
+        args: ["--all-targets", "--", "-D", "warnings", "-W", "clippy::pedantic", "-A", "clippy::module-name-repetitions"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
 #####
 # R
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.2
+    rev: v0.4.3
     hooks:
     -   id: style-files
     -   id: lintr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,23 +12,18 @@ repos:
     -   id: trailing-whitespace
 #####
 # Python
--   repo: https://github.com/psf/black
-    rev: 23.10.0
-    hooks:
-        # if you have ipython notebooks, consider using
-        # `black-jupyter` hook instead
-    -   id: black
-        args: ['--line-length', '79']
--   repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
-        args: ['--profile', 'black',
-               '--line-length', '79']
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.0
+  rev: v0.6.8
   hooks:
+    # Sort imports
     - id: ruff
+      args: ['check', '--select', 'I', '--fix']
+    # Run the linter
+    - id: ruff
+      args: ['--line-length', '79']
+    # Run the formatter
+    - id: ruff-format
+      args: ['--line-length', '79']
 #####
 # R
 -   repo: https://github.com/lorenzwalthert/precommit
@@ -59,11 +54,3 @@ repos:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: package.lock.json
--   repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
-    hooks:
-    -   id: fmt
-        args: ["--verbose", "--"]
-    -   id: clippy
-        # Use 'all-targets' to run on all code, including tests and examples
-        args: ["--all-targets", "--", "-D", "warnings", "-W", "clippy::pedantic", "-A", "clippy::module-name-repetitions"]


### PR DESCRIPTION
Not sure why CI in #41 didn't complain that the pre-commit workflow needed packages cached. When I include this commit in #40, pre-commit on Github Actions passes. While I was at it, I updated the styler and used ruff over black in line with the current CFA repo template.