### PR TITLE
[Part 1]: Update get_contact and add setting module 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 clap = { version = "4.5.21", features = ["derive"] }
 ctor = "0.2.9"
 csv = "1.3.1"
-ixa = { git = "https://github.com/cdcgov/ixa.git", branch = "k88hudson_query_and_clone" }
-ixa-derive = { git = "https://github.com/cdcgov/ixa", version = "0.0.0" }
+ixa = { git = "https://github.com/cdcgov/ixa.git", branch = "main" }
+ixa-derive = { git = "https://github.com/cdcgov/ixa", branch = "main" }
 paste = "1.0.15"
 rand = "0.8.5"
 tempfile = "3.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 clap = { version = "4.5.21", features = ["derive"] }
 ctor = "0.2.9"
 csv = "1.3.1"
-ixa = { git = "https://github.com/cdcgov/ixa", version = "0.0.1" }
+ixa = { git = "https://github.com/cdcgov/ixa.git", branch = "k88hudson_query_and_clone" }
 ixa-derive = { git = "https://github.com/cdcgov/ixa", version = "0.0.0" }
 paste = "1.0.15"
 rand = "0.8.5"
-serde = "1.0.215"
-serde_derive = "1.0.215"
 tempfile = "3.14.0"
 statrs = "0.17.1"
+serde = "1.0.217"
+serde_derive = "1.0.217"

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,43 +1,29 @@
-use ixa::{define_rng, Context, ContextPeopleExt, IxaError, PersonId};
-
-use crate::population_loader::Alive;
+use ixa::{define_rng, people::Query, Context, ContextPeopleExt, PersonId};
 
 define_rng!(ContactRng);
 
 pub trait ContextContactExt {
-    /// Returns a potential contact for the transmitter.
-    /// Returns Ok(None) if there are no eligible contacts.
-    /// In the future, this function can be expanded to return a
-    /// contact specific to the person's household or to weight
-    /// drawing contacts be a contact matrix.
-    ///
-    /// Errors
-    /// - If there is only one person in the population.
-    fn get_contact(&mut self, transmitter_id: PersonId) -> Result<Option<PersonId>, IxaError>;
+    /// Returns a potential contact for the transmitter given a query of people
+    /// properties, for example `(Alive, true)`.
+    /// Returns None if there are no eligible contacts.
+    fn get_contact<Q: Query>(&self, transmitter_id: PersonId, query: Q) -> Option<PersonId>;
 }
 
 impl ContextContactExt for Context {
-    fn get_contact(&mut self, transmitter_id: PersonId) -> Result<Option<PersonId>, IxaError> {
-        if self.get_current_population() == 1 {
-            return Err(IxaError::IxaError(
-                "Cannot get a contact when there is only one person in the population.".to_string(),
-            ));
-        };
-        // Get list of eligible people (for now, all alive people). May be expanded in the future
-        // to instead be list of alive people in the transmitter's contact setting or household.
+    fn get_contact<Q: Query>(&self, transmitter_id: PersonId, query: Q) -> Option<PersonId> {
+        // Get list of eligible people given the provided query
         // We sample a random person from this list.
-        if self.query_people((Alive, true)).len() > 1 {
+        if self.query_people(query.clone()).len() > 1 {
             let mut contact_id = transmitter_id;
             while contact_id == transmitter_id {
-                // In the future, we might like to sample people from the list by weights according
-                // to some contact matrix. We would use sample_weighted instead. We would calculate
-                // the weights _before_ the loop and then sample from the list of people like here.
-                contact_id = self.sample_person(ContactRng, (Alive, true))?;
+                contact_id = match self.sample_person(ContactRng, query.clone()) {
+                    Ok(id) => id,
+                    Err(_) => return None,
+                };
             }
-            Ok(Some(contact_id))
+            Some(contact_id)
         } else {
-            // This means that there are no eligible contacts in the population besides the transmitter.
-            Ok(None)
+            None
         }
     }
 }
@@ -45,29 +31,28 @@ impl ContextContactExt for Context {
 #[cfg(test)]
 mod test {
     use super::ContextContactExt;
-    use crate::population_loader::Alive;
-    use ixa::{Context, ContextPeopleExt, ContextRandomExt, IxaError};
+    use ixa::{define_person_property_with_default, Context, ContextPeopleExt, ContextRandomExt};
+
+    define_person_property_with_default!(Alive, bool, true);
 
     #[test]
     fn test_cant_get_contact_in_pop_of_one() {
         let mut context = Context::new();
-        let transmitter = context.add_person(()).unwrap();
-        let e = context.get_contact(transmitter);
-        match e {
-            Err(IxaError::IxaError(msg)) => assert_eq!(msg, "Cannot get a contact when there is only one person in the population.".to_string()),
-            Err(ue) => panic!("Expected an error that there should be no contacts when there is only one person in the population. Instead got {:?}", ue.to_string()),
-            Ok(Some(contact)) => panic!("Expected an error. Instead, got {contact:?} as valid contact."),
-            Ok(None) => panic!("Expected an error. Instead, returned None, meaning that there are no valid contacts."),
-        }
+        context.init_random(108);
+        let transmitter = context.add_person((Alive, true)).unwrap();
+        let result = context.get_contact(transmitter, ());
+        assert!(result.is_none());
     }
 
     #[test]
-    fn test_return_none() {
+    fn test_return_none_transmitter_only_contact() {
         let mut context = Context::new();
         context.init_random(108);
-        let transmitter = context.add_person(()).unwrap();
-        let _ = context.add_person((Alive, false)).unwrap();
-        let observed_contact = context.get_contact(transmitter).unwrap();
+        let transmitter = context.add_person((Alive, true)).unwrap();
+        context.add_person((Alive, false)).unwrap();
+        context.add_person((Alive, false)).unwrap();
+
+        let observed_contact = context.get_contact(transmitter, (Alive, true));
         assert!(observed_contact.is_none());
     }
 
@@ -75,10 +60,14 @@ mod test {
     fn test_return_remaining_alive_person() {
         let mut context = Context::new();
         context.init_random(108);
-        let transmitter = context.add_person(()).unwrap();
-        let _ = context.add_person((Alive, false)).unwrap();
-        let presumed_contact = context.add_person(()).unwrap();
-        let observed_contact = context.get_contact(transmitter).unwrap();
-        assert_eq!(observed_contact.unwrap(), presumed_contact);
+        let transmitter = context.add_person((Alive, true)).unwrap();
+        let presumed_contact = context.add_person((Alive, true)).unwrap();
+        // Add some more people that don't match
+        context.add_person((Alive, false)).unwrap();
+        context.add_person((Alive, false)).unwrap();
+        context.add_person((Alive, false)).unwrap();
+
+        let observed_contact = context.get_contact(transmitter, (Alive, true)).unwrap();
+        assert_eq!(observed_contact, presumed_contact);
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -13,10 +13,10 @@ impl ContextContactExt for Context {
     fn get_contact<Q: Query>(&self, transmitter_id: PersonId, query: Q) -> Option<PersonId> {
         // Get list of eligible people given the provided query
         // We sample a random person from this list.
-        if self.query_people(query.clone()).len() > 1 {
+        if self.query_people(query).len() > 1 {
             let mut contact_id = transmitter_id;
             while contact_id == transmitter_id {
-                contact_id = match self.sample_person(ContactRng, query.clone()) {
+                contact_id = match self.sample_person(ContactRng, query) {
                     Ok(id) => id,
                     Err(_) => return None,
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 mod contact;
 mod parameters;
 mod population_loader;
+pub mod settings;
 mod transmission_manager;
 
 use ixa::runner::run_with_args;
 use ixa::{ContextGlobalPropertiesExt, ContextPeopleExt, ContextRandomExt, ContextReportExt};
+use parameters::Parameters;
+use population_loader::{Age, CensusTract};
 use transmission_manager::InfectiousStatus;
-
-use crate::parameters::Parameters;
-use crate::population_loader::{Age, CensusTract};
 
 fn main() {
     run_with_args(|context, _, _| {

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -1,4 +1,3 @@
-use crate::parameters::Parameters;
 use ixa::{
     define_person_property, define_person_property_with_default, Context,
     ContextGlobalPropertiesExt, ContextPeopleExt, IxaError,
@@ -6,6 +5,8 @@ use ixa::{
 
 use serde::Deserialize;
 use std::path::PathBuf;
+
+use crate::{define_setting, parameters::Parameters};
 
 #[derive(Deserialize, Debug)]
 #[allow(non_snake_case)]
@@ -15,9 +16,10 @@ pub struct PeopleRecord<'a> {
 }
 
 define_person_property!(Age, u8);
-define_person_property!(HomeId, usize);
 define_person_property_with_default!(Alive, bool, true);
-define_person_property!(CensusTract, usize);
+
+define_setting!(Household);
+define_setting!(CensusTract);
 
 fn create_person_from_record(
     context: &mut Context,
@@ -28,7 +30,7 @@ fn create_person_from_record(
 
     let _person_id = context.add_person((
         (Age, person_record.age),
-        (HomeId, home_id.parse()?),
+        (Household, home_id.parse()?),
         (CensusTract, tract.parse()?),
     ))?;
 
@@ -49,7 +51,6 @@ fn load_synth_population(context: &mut Context, synth_input_file: PathBuf) -> Re
 
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
     let parameters = context.get_global_property_value(Parameters).unwrap();
-
     load_synth_population(context, parameters.synth_population_file.clone())
 }
 
@@ -86,7 +87,7 @@ mod test {
                 context.query_people_count((
                     (Age, age[i]),
                     (CensusTract, tract[i]),
-                    (HomeId, home_id[i]),
+                    (Household, home_id[i]),
                 ))
             );
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,151 @@
+use crate::contact::ContextContactExt;
+use ixa::{
+    people::{Query, QueryAnd},
+    Context, ContextPeopleExt, PersonId, PersonProperty,
+};
+
+// TODO<ryl8@cdc.gov> This is usize for now, but it could be a real type
+type SettingId = usize;
+pub trait Setting: PersonProperty<Value = SettingId> + 'static + Copy + Clone {
+    fn get_name(&self) -> String;
+}
+
+#[macro_export]
+macro_rules! define_setting {
+    ($name:ident) => {
+        paste::paste! {
+            ixa::define_person_property!($name, usize);
+            impl $crate::settings::Setting for $name {
+                fn get_name(&self) -> String {
+                    stringify!($name).to_string()
+                }
+            }
+        }
+    };
+}
+
+pub trait ContextSettingExt {
+    /// Get a person's setting identifier
+    fn get_person_setting_id<S: Setting>(&self, person_id: PersonId, setting: S) -> usize;
+    // Set a person's setting identifier
+    fn set_person_setting_id<S: Setting>(
+        &mut self,
+        person_id: PersonId,
+        setting: S,
+        setting_id: SettingId,
+    );
+    /// Return all members of the setting; you can pass a query to filter members
+    /// with additional properties, fo example `(Alive, true)`
+    fn get_setting_members<S: Setting, Q: Query>(
+        &self,
+        _setting: S,
+        setting_id: SettingId,
+        query: Q,
+    ) -> Vec<PersonId>;
+    /// Get a contact for a particular setting (other than the person themselves)
+    fn get_contact_from_setting<S: Setting, Q: Query + Clone>(
+        &self,
+        person_id: PersonId,
+        setting: S,
+        q: Q,
+    ) -> Option<PersonId>;
+}
+
+impl ContextSettingExt for Context {
+    fn get_person_setting_id<S: Setting>(&self, person_id: PersonId, _setting: S) -> SettingId {
+        self.get_person_property(person_id, S::get_instance())
+    }
+    fn set_person_setting_id<S: Setting>(
+        &mut self,
+        person_id: PersonId,
+        _setting: S,
+        setting_id: SettingId,
+    ) {
+        self.set_person_property(person_id, S::get_instance(), setting_id);
+    }
+    fn get_setting_members<S: Setting, Q: Query>(
+        &self,
+        _setting: S,
+        setting_id: SettingId,
+        query: Q,
+    ) -> Vec<PersonId> {
+        self.query_people(QueryAnd::new((S::get_instance(), setting_id), query))
+    }
+    fn get_contact_from_setting<S: Setting, Q: Query>(
+        &self,
+        person_id: PersonId,
+        _setting: S,
+        q: Q,
+    ) -> Option<PersonId> {
+        let setting_id = self.get_person_setting_id(person_id, S::get_instance());
+        self.get_contact(person_id, QueryAnd::new((S::get_instance(), setting_id), q))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ixa::define_person_property_with_default;
+    use ixa::define_rng;
+    use ixa::Context;
+    use ixa::ContextPeopleExt;
+    use ixa::ContextRandomExt;
+
+    define_rng!(TestSettingRng);
+    define_setting!(Group);
+    define_person_property_with_default!(Alive, bool, true);
+
+    #[test]
+    fn test_get_name() {
+        assert_eq!(Group.get_name(), "Group");
+    }
+
+    #[test]
+    fn test_person_get_set_setting() {
+        let mut ctx = ixa::Context::new();
+        let p = ctx.add_person((Group, 1)).unwrap();
+
+        // Trait extension
+        assert_eq!(ctx.get_person_setting_id(p, Group), 1);
+
+        // Set person 1’s group setting to 10 and verify it.
+        ctx.set_person_setting_id(p, Group, 10);
+        assert_eq!(ctx.get_person_setting_id(p, Group), 10);
+    }
+
+    #[test]
+    fn test_get_members() {
+        let mut ctx = ixa::Context::new();
+        let p1 = ctx.add_person((Group, 5)).unwrap();
+        let p2 = ctx.add_person((Group, 5)).unwrap();
+        ctx.add_person((Group, 10)).unwrap();
+
+        // Query for members of group 5.
+        let members = ctx.get_setting_members(Group, 5, ());
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&p1));
+        assert!(members.contains(&p2));
+    }
+
+    #[test]
+    fn test_return_setting_contact_none_when_only_contact() {
+        let mut context = Context::new();
+        context.init_random(108);
+        let transmitter = context.add_person((Group, 1)).unwrap();
+        context.add_person(((Alive, false), (Group, 1))).unwrap();
+        let observed_contact = context.get_contact_from_setting(transmitter, Group, (Alive, true));
+        assert!(observed_contact.is_none());
+    }
+
+    #[test]
+    fn test_return_setting_contact() {
+        let mut context = Context::new();
+        context.init_random(108);
+        let transmitter = context.add_person((Group, 1)).unwrap();
+        let expected = context.add_person(((Alive, true), (Group, 1))).unwrap();
+        context.add_person(((Alive, false), (Group, 1))).unwrap();
+        context.add_person(((Alive, true), (Group, 2))).unwrap();
+        let observed_contact = context.get_contact_from_setting(transmitter, Group, (Alive, true));
+        assert_eq!(observed_contact, Some(expected));
+    }
+}

--- a/src/transmission_manager.rs
+++ b/src/transmission_manager.rs
@@ -118,8 +118,7 @@ fn schedule_next_infection_attempt(
     context.add_plan(
         context.get_current_time() + time_until_next_infection_attempt_gi,
         move |context| {
-            infection_attempt(context, transmitter_id)
-                .expect("Error finding contact in infection attempt");
+            infection_attempt(context, transmitter_id);
             // Schedule the next infection attempt for this infected agent
             // once the last infection attempt is over.
             schedule_next_infection_attempt(
@@ -180,18 +179,14 @@ fn gi_inverse_cdf(context: &Context, uniform_draw: f64) -> f64 {
 /// and as long as it returns a valid contact id, it can use any sampling strategy.
 /// In other words, this code does not depend on the sampling logic, but it also doesn't
 /// check any characteristics of the contact.
-/// Errors
-/// - If there is only one person in the population.
-fn infection_attempt(context: &mut Context, transmitter_id: PersonId) -> Result<(), IxaError> {
-    // `get_contact`? returns Option<PersonId>. If the option is None, there are no valid
+fn infection_attempt(context: &mut Context, transmitter_id: PersonId) {
+    // If the option is None, there are no valid
     // contacts to infect, so do nothing.
-    if let Some(contact_id) = context.get_contact(transmitter_id)? {
+    if let Some(contact_id) = context.get_contact(transmitter_id, (Alive, true)) {
         // We evaluate transmission in its own function because there will be eventually
         // be intervention-based logic that determines whether a transmission event is successful.
         evaluate_transmission(context, contact_id, transmitter_id);
     }
-
-    Ok(())
 }
 
 /// Evaluates whether a transmission event is successful based on the characteristics


### PR DESCRIPTION
This PR generalizes `get_contact` to take a query and implements a simple `Settings` module with some utilities (including `get_contact_from_setting`, which will be useful in the updated version of this model).

Right now a `Setting` is just a trait implemented on a `PersonProperty`; in the future, we're going to want to store some data associated with settings and also have some utilities around defining a person's itinerary, choosing a setting for them to draw a contact from, etc.