### PR TITLE
Change `InfectionStatusValue::Infected` to be `InfectionStatusValue::Infectious`

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -55,9 +55,9 @@ pub fn load_rate_fns(context: &mut Context) {
     )));
 }
 
-/// Seeds the initial population with a number of infected people.
+/// Seeds the initial population with a number of infectious people.
 fn seed_infections(context: &mut Context, initial_infections: usize) {
-    // First, seed an infected population
+    // First, seed an infectious population
     for _ in 0..initial_infections {
         let person = context.sample_person(InfectionRng, ()).unwrap();
         context.infect_person(person);
@@ -127,10 +127,10 @@ mod test {
         }
         load_rate_fns(&mut context);
         seed_infections(&mut context, 5);
-        let infected_count = context
+        let infectious_count = context
             .query_people((InfectionStatus, InfectionStatusValue::Infectious))
             .len();
-        assert_eq!(infected_count, 5);
+        assert_eq!(infectious_count, 5);
     }
 
     #[test]
@@ -143,7 +143,7 @@ mod test {
         init(&mut context);
 
         let &Params {
-            initial_infections: expected_infected,
+            initial_infections: expected_infectious,
             ..
         } = context.get_params();
 
@@ -152,11 +152,11 @@ mod test {
         context.add_plan_with_phase(
             0.0,
             move |context| {
-                let infected_count = context
+                let infectious_count = context
                     .query_people((InfectionStatus, InfectionStatusValue::Infectious))
                     .len();
                 assert_eq!(
-                    infected_count, expected_infected,
+                    infectious_count, expected_infectious,
                     "Infections should be seeded at 0.0"
                 );
             },

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -77,7 +77,7 @@ pub fn init(context: &mut Context) {
     });
 
     context.subscribe_to_event::<PersonPropertyChangeEvent<InfectionStatus>>(|context, event| {
-        if event.current != InfectionStatusValue::Infected {
+        if event.current != InfectionStatusValue::Infectious {
             return;
         }
         schedule_next_forecasted_infection(context, event.person_id);
@@ -128,7 +128,7 @@ mod test {
         load_rate_fns(&mut context);
         seed_infections(&mut context, 5);
         let infected_count = context
-            .query_people((InfectionStatus, InfectionStatusValue::Infected))
+            .query_people((InfectionStatus, InfectionStatusValue::Infectious))
             .len();
         assert_eq!(infected_count, 5);
     }
@@ -153,7 +153,7 @@ mod test {
             0.0,
             move |context| {
                 let infected_count = context
-                    .query_people((InfectionStatus, InfectionStatusValue::Infected))
+                    .query_people((InfectionStatus, InfectionStatusValue::Infectious))
                     .len();
                 assert_eq!(
                     infected_count, expected_infected,

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -14,7 +14,7 @@ use crate::{
 #[derive(Serialize, PartialEq, Debug, Clone, Copy)]
 pub enum InfectionDataValue {
     Susceptible,
-    Infected {
+    Infectious {
         infection_time: f64,
         rate_fn_id: RateFnId,
     },
@@ -27,7 +27,7 @@ pub enum InfectionDataValue {
 #[derive(Serialize, PartialEq, Debug, Clone, Copy)]
 pub enum InfectionStatusValue {
     Susceptible,
-    Infected,
+    Infectious,
     Recovered,
 }
 
@@ -43,7 +43,7 @@ define_derived_property!(
     [InfectionData],
     |data| match data {
         InfectionDataValue::Susceptible => InfectionStatusValue::Susceptible,
-        InfectionDataValue::Infected { .. } => InfectionStatusValue::Infected,
+        InfectionDataValue::Infectious { .. } => InfectionStatusValue::Infectious,
         InfectionDataValue::Recovered { .. } => InfectionStatusValue::Recovered,
     }
 );
@@ -168,7 +168,7 @@ impl InfectionContextExt for Context {
         self.set_person_property(
             person_id,
             InfectionData,
-            InfectionDataValue::Infected {
+            InfectionDataValue::Infectious {
                 infection_time,
                 rate_fn_id,
             },
@@ -177,7 +177,7 @@ impl InfectionContextExt for Context {
 
     fn recover_person(&mut self, person_id: PersonId) {
         let recovery_time = self.get_current_time();
-        let InfectionDataValue::Infected { infection_time, .. } =
+        let InfectionDataValue::Infectious { infection_time, .. } =
             self.get_person_property(person_id, InfectionData)
         else {
             panic!("Person {person_id} is not infected")
@@ -193,7 +193,7 @@ impl InfectionContextExt for Context {
     }
 
     fn get_person_rate_fn(&self, person_id: PersonId) -> &dyn InfectiousnessRateFn {
-        let InfectionDataValue::Infected { rate_fn_id, .. } =
+        let InfectionDataValue::Infectious { rate_fn_id, .. } =
             self.get_person_property(person_id, InfectionData)
         else {
             panic!("Person {person_id} is not infected")
@@ -202,7 +202,7 @@ impl InfectionContextExt for Context {
     }
 
     fn get_elapsed_infection_time(&self, person_id: PersonId) -> f64 {
-        let InfectionDataValue::Infected { infection_time, .. } =
+        let InfectionDataValue::Infectious { infection_time, .. } =
             self.get_person_property(person_id, InfectionData)
         else {
             panic!("Person {person_id} is not infected")
@@ -257,7 +257,7 @@ mod test {
             context.infect_person(p1);
         });
         context.execute();
-        let InfectionDataValue::Infected { infection_time, .. } =
+        let InfectionDataValue::Infectious { infection_time, .. } =
             context.get_person_property(p1, InfectionData)
         else {
             panic!("Person {p1} is not infected")


### PR DESCRIPTION
"Infectious" implies that the person is capable of transmitting disease while "infected" simply says that the person has succumbed to infection. We are interested in when people transmit disease (which may be disconnected from when they "recover" in terms of symptoms), so we want to use "infectious" to better indicate that this status refers to people who are actively capable of infecting others, regardless of their other clinical statuses.