### PR TITLE
Add statistical tests for infection loop. Closes #52.

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -101,12 +101,12 @@ mod test {
 
     use super::seed_infections;
 
-    fn setup_context() -> Context {
+    fn setup_context(seed: u64) -> Context {
         let mut context = Context::new();
         let parameters = Params {
             initial_infections: 3,
             max_time: 100.0,
-            seed: 0,
+            seed,
             rate_of_infection: 1.0,
             infection_duration: 5.0,
             report_period: 1.0,
@@ -122,7 +122,7 @@ mod test {
 
     #[test]
     fn test_seed_infections() {
-        let mut context = setup_context();
+        let mut context = setup_context(0);
         for _ in 0..10 {
             context.add_person(()).unwrap();
         }
@@ -136,7 +136,7 @@ mod test {
 
     #[test]
     fn test_init_loop() {
-        let mut context = setup_context();
+        let mut context = setup_context(0);
         for _ in 0..10 {
             context.add_person(()).unwrap();
         }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -244,7 +244,7 @@ mod test {
             load_rate_fns(&mut context);
             // Add our infectious fellow.
             let infectious_person = context.add_person(()).unwrap();
-            context.infect_person(infectious_person);
+            context.infect_person(infectious_person, None);
             // Get the total infectiousness multiplier for comparison to total number of infections.
             if total_infectiousness_multiplier.is_none() {
                 total_infectiousness_multiplier = Some(max_total_infectiousness_multiplier(

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -195,7 +195,7 @@ mod test {
         let num_new_infections_clone = Rc::clone(&num_new_infections);
         context.subscribe_to_event::<PersonPropertyChangeEvent<InfectionStatus>>(
             move |_context, event| {
-                if event.current == InfectionStatusValue::Infected {
+                if event.current == InfectionStatusValue::Infectious {
                     *num_new_infections_clone.borrow_mut() += 1;
                 }
             },
@@ -253,7 +253,7 @@ mod test {
             // Add a watcher for when people are infected to record the infection times.
             context.subscribe_to_event::<PersonPropertyChangeEvent<InfectionStatus>>(
                 move |context, event| {
-                    if event.current == InfectionStatusValue::Infected {
+                    if event.current == InfectionStatusValue::Infectious {
                         let current_time = context.get_current_time();
                         infection_times_clone.borrow_mut().push(current_time);
                     }
@@ -264,12 +264,12 @@ mod test {
             schedule_recovery(&mut context, infectious_person);
             context.execute();
             let mut infected_count = context
-                .query_people((InfectionStatus, InfectionStatusValue::Infected))
+                .query_people((InfectionStatus, InfectionStatusValue::Infectious))
                 .len();
             // If our initial infection is still infected, we have to subtract one from our recorded
             // number of infected people.
             if context.get_person_property(infectious_person, InfectionStatus)
-                == InfectionStatusValue::Infected
+                == InfectionStatusValue::Infectious
             {
                 infected_count -= 1;
             }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -224,10 +224,10 @@ mod test {
         let rate = 1.5;
         // We need the total infectiousness multiplier for the person.
         let mut total_infectiousness_multiplier = None;
-        let mut num_infections_end_one_time_unit = [0usize; NUM_SIMS];
-        // Where we store the infection times
+        let mut num_infections_end_one_time_unit = Vec::<usize>::with_capacity(NUM_SIMS);
+        // Where we store the infection times.
         let infection_times = Rc::new(RefCell::new(Vec::<f64>::new()));
-        for (seed, num_infections) in num_infections_end_one_time_unit.iter_mut().enumerate() {
+        for seed in 0..NUM_SIMS {
             let infection_times_clone = Rc::clone(&infection_times);
             let mut context = setup_context(seed.try_into().unwrap(), rate);
             // We only run the simulation for 1.0 time units.
@@ -273,7 +273,7 @@ mod test {
             {
                 infected_count -= 1;
             }
-            *num_infections = infected_count;
+            num_infections_end_one_time_unit.push(infected_count);
         }
         #[allow(clippy::cast_precision_loss)]
         let avg_number_infections =

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -220,16 +220,16 @@ mod test {
         // We're also going to check the times at which they are infected -- since we only record
         // infection times of when people are actually infected, we expect the times to be uniform
         // on [0, 1].
-        const NUM_SIMS: usize = 10000;
+        let num_sims: u64 = 10000;
         let rate = 1.5;
         // We need the total infectiousness multiplier for the person.
         let mut total_infectiousness_multiplier = None;
-        let mut num_infections_end_one_time_unit: usize = 0;
+        let mut num_infections_end_one_time_unit = 0;
         // Where we store the infection times.
         let infection_times = Rc::new(RefCell::new(Vec::<f64>::new()));
-        for seed in 0..NUM_SIMS {
+        for seed in 0..num_sims {
             let infection_times_clone = Rc::clone(&infection_times);
-            let mut context = setup_context(seed.try_into().unwrap(), rate);
+            let mut context = setup_context(seed, rate);
             // We only run the simulation for 1.0 time units.
             context.add_plan_with_phase(1.0, ixa::Context::shutdown, ExecutionPhase::Last);
             // Add a bunch of people so we mimic an infinitely large population.
@@ -276,7 +276,7 @@ mod test {
             num_infections_end_one_time_unit += infected_count;
         }
         #[allow(clippy::cast_precision_loss)]
-        let avg_number_infections = num_infections_end_one_time_unit as f64 / NUM_SIMS as f64;
+        let avg_number_infections = num_infections_end_one_time_unit as f64 / num_sims as f64;
         assert_almost_eq!(
             avg_number_infections,
             rate * total_infectiousness_multiplier.unwrap(),

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -220,9 +220,15 @@ mod test {
         // infected, so this is really a setup where there is no susceptible depletion/an
         // infinitely large starting population. We stop the simulation at the end of 1.0 time units
         // and compare the number of infected people to the infectious rate.
-        // We're also going to check the times at which they are infected -- since we only record
-        // infection times of when people are actually infected, we expect the times to be uniform
-        // on [0, 1].
+        // We're also going to check the times at which they are infected. In this test simulation,
+        // we are using a constant hazard of infection, and we only record infection times that are
+        // within 1.0 time units, so we expect the timing of infection attempts to follow U(0, 1).
+        // First, we should not expect to observe an exponential distribution because we may observe
+        // multiple infection attempts in the same experiment, not just the first. This also helps
+        // provide intuition for why we expect a uniform distribution -- if the first infection
+        // attempt happens quickly, that increases the chance we see another in 1.0 time units, and
+        // because there is basically this compensating relationship between the time and the number
+        // of events, they "cancel" each other out to give a uniform distribution (handwavingly).
         let num_sims: u64 = 10000;
         let rate = 1.5;
         // We need the total infectiousness multiplier for the person.

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -224,7 +224,7 @@ mod test {
         let rate = 1.5;
         // We need the total infectiousness multiplier for the person.
         let mut total_infectiousness_multiplier = None;
-        let mut num_infections_end_one_time_unit = Vec::<usize>::with_capacity(NUM_SIMS);
+        let mut num_infections_end_one_time_unit: usize = 0;
         // Where we store the infection times.
         let infection_times = Rc::new(RefCell::new(Vec::<f64>::new()));
         for seed in 0..NUM_SIMS {
@@ -273,11 +273,10 @@ mod test {
             {
                 infected_count -= 1;
             }
-            num_infections_end_one_time_unit.push(infected_count);
+            num_infections_end_one_time_unit += infected_count;
         }
         #[allow(clippy::cast_precision_loss)]
-        let avg_number_infections =
-            num_infections_end_one_time_unit.iter().sum::<usize>() as f64 / NUM_SIMS as f64;
+        let avg_number_infections = num_infections_end_one_time_unit as f64 / NUM_SIMS as f64;
         assert_almost_eq!(
             avg_number_infections,
             rate * total_infectiousness_multiplier.unwrap(),

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -185,11 +185,7 @@ mod test {
     #[test]
     fn test_zero_rate_no_infections() {
         let mut context = setup_context(0, 0.0);
-        for _ in 0..=context
-            .get_global_property_value(Parameters)
-            .unwrap()
-            .initial_infections
-        {
+        for _ in 0..=context.get_params().initial_infections {
             context.add_person(()).unwrap();
         }
 
@@ -209,10 +205,7 @@ mod test {
 
         assert_eq!(
             *num_new_infections.borrow(),
-            context
-                .get_global_property_value(Parameters)
-                .unwrap()
-                .initial_infections
+            context.get_params().initial_infections
         );
     }
 


### PR DESCRIPTION
This is inspired by the tests we had the previous transmission manager (see #51's deleted files) but welcome suggestions for other statistical tests to include.