### PR TITLE
Integrate infection duration into `InfectiousnessRateFn`. Proposal to close #55.

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -29,9 +29,7 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
 }
 
 fn schedule_recovery(context: &mut Context, person: PersonId) {
-    let infection_duration = context
-        .get_person_rate_fn(person)
-        .infection_duration_remaining(0.0);
+    let infection_duration = context.get_person_rate_fn(person).infection_duration();
     let recovery_time = context.get_current_time() + infection_duration;
     context.add_plan(recovery_time, move |context| {
         trace!("Person {person} has recovered at {recovery_time}");
@@ -321,9 +319,7 @@ mod test {
         let person = context.add_person(()).unwrap();
         seed_infections(&mut context, 1);
         // For later, we need to get the recovery time from the rate function.
-        let recovery_time = context
-            .get_person_rate_fn(person)
-            .infection_duration_remaining(0.0);
+        let recovery_time = context.get_person_rate_fn(person).infection_duration();
         schedule_recovery(&mut context, person);
         context.execute();
         // Make sure person is recovered.

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -96,7 +96,6 @@ mod test {
         assert_almost_eq,
         distribution::{ContinuousCDF, Uniform},
     };
-    use statrs::assert_almost_eq;
 
     use crate::{
         infection_propagation_loop::{
@@ -314,7 +313,7 @@ mod test {
 
     #[test]
     fn test_schedule_recovery() {
-        let mut context = setup_context();
+        let mut context = setup_context(0, 0.0);
         load_rate_fns(&mut context);
         let person = context.add_person(()).unwrap();
         seed_infections(&mut context, 1);

--- a/src/rate_fns/constant_rate.rs
+++ b/src/rate_fns/constant_rate.rs
@@ -43,6 +43,8 @@ impl InfectiousnessRateFn for ConstantRate {
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod test {
+    use statrs::assert_almost_eq;
+
     use super::ConstantRate;
     use super::InfectiousnessRateFn;
 
@@ -66,5 +68,13 @@ mod test {
         assert_eq!(r.inverse_cum_rate(10.0), Some(5.0));
         assert_eq!(r.inverse_cum_rate(20.0), Some(10.0));
         assert_eq!(r.inverse_cum_rate(21.0), None);
+    }
+
+    #[test]
+    fn test_infection_duration_remaining() {
+        let r = ConstantRate::new(2.0, 10.0);
+        assert_almost_eq!(r.infection_duration_remaining(0.0), 10.0, 0.0);
+        assert_almost_eq!(r.infection_duration_remaining(3.0), 7.0, 0.0);
+        assert_almost_eq!(r.infection_duration_remaining(13.0), -3.0, 0.0);
     }
 }

--- a/src/rate_fns/constant_rate.rs
+++ b/src/rate_fns/constant_rate.rs
@@ -35,8 +35,8 @@ impl InfectiousnessRateFn for ConstantRate {
             Some(t)
         }
     }
-    fn infection_duration_remaining(&self, t: f64) -> f64 {
-        self.infection_duration - t
+    fn infection_duration(&self) -> f64 {
+        self.infection_duration
     }
 }
 
@@ -71,10 +71,8 @@ mod test {
     }
 
     #[test]
-    fn test_infection_duration_remaining() {
+    fn test_infection_duration() {
         let r = ConstantRate::new(2.0, 10.0);
-        assert_almost_eq!(r.infection_duration_remaining(0.0), 10.0, 0.0);
-        assert_almost_eq!(r.infection_duration_remaining(3.0), 7.0, 0.0);
-        assert_almost_eq!(r.infection_duration_remaining(13.0), -3.0, 0.0);
+        assert_almost_eq!(r.infection_duration(), 10.0, 0.0);
     }
 }

--- a/src/rate_fns/constant_rate.rs
+++ b/src/rate_fns/constant_rate.rs
@@ -35,6 +35,9 @@ impl InfectiousnessRateFn for ConstantRate {
             Some(t)
         }
     }
+    fn infection_duration_remaining(&self, t: f64) -> f64 {
+        self.infection_duration - t
+    }
 }
 
 #[cfg(test)]

--- a/src/rate_fns/empirical_rate.rs
+++ b/src/rate_fns/empirical_rate.rs
@@ -509,4 +509,15 @@ mod test {
         // greater than 3.0 because the rate starts moving again after t = 3.0.
         assert!(empirical.inverse_cum_rate(1.6).unwrap() > 3.0);
     }
+
+    #[test]
+    fn test_infection_duration_remaining() {
+        let empirical = EmpiricalRate::new(
+            vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            vec![1.0, 1.0, 0.0, 0.0, 1.0, 0.0],
+        )
+        .unwrap();
+        assert_almost_eq!(empirical.infection_duration_remaining(2.0), 3.0, 0.0);
+        assert_almost_eq!(empirical.infection_duration_remaining(7.0), -2.0, 0.0);
+    }
 }

--- a/src/rate_fns/empirical_rate.rs
+++ b/src/rate_fns/empirical_rate.rs
@@ -144,7 +144,7 @@ impl InfectiousnessRateFn for EmpiricalRate {
     }
 
     fn inverse_cum_rate(&self, events: f64) -> Option<f64> {
-        if events > *self.cum_rates.last().unwrap() {
+        if events > self.cum_rates[self.cum_rates.len() - 1] {
             return None;
         }
         // We want to return the time at which `events` would have happened. At a high level, this
@@ -218,6 +218,10 @@ impl InfectiousnessRateFn for EmpiricalRate {
         // *accumulating* extra area.
         let t = (-self.instantaneous_rate[integration_index] + f64::sqrt(discriminant)) / slope;
         Some(self.times[integration_index] + t)
+    }
+
+    fn infection_duration_remaining(&self, t: f64) -> f64 {
+        self.times[self.times.len() - 1] - t
     }
 }
 

--- a/src/rate_fns/empirical_rate.rs
+++ b/src/rate_fns/empirical_rate.rs
@@ -220,8 +220,8 @@ impl InfectiousnessRateFn for EmpiricalRate {
         Some(self.times[integration_index] + t)
     }
 
-    fn infection_duration_remaining(&self, t: f64) -> f64 {
-        self.times[self.times.len() - 1] - t
+    fn infection_duration(&self) -> f64 {
+        self.times[self.times.len() - 1]
     }
 }
 
@@ -511,13 +511,12 @@ mod test {
     }
 
     #[test]
-    fn test_infection_duration_remaining() {
+    fn test_infection_duration() {
         let empirical = EmpiricalRate::new(
             vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
             vec![1.0, 1.0, 0.0, 0.0, 1.0, 0.0],
         )
         .unwrap();
-        assert_almost_eq!(empirical.infection_duration_remaining(2.0), 3.0, 0.0);
-        assert_almost_eq!(empirical.infection_duration_remaining(7.0), -2.0, 0.0);
+        assert_almost_eq!(empirical.infection_duration(), 5.0, 0.0);
     }
 }

--- a/src/rate_fns/empirical_rate.rs
+++ b/src/rate_fns/empirical_rate.rs
@@ -518,5 +518,13 @@ mod test {
         )
         .unwrap();
         assert_almost_eq!(empirical.infection_duration(), 5.0, 0.0);
+
+        // Show that the infection duration is agnostic to the value in `instantaneous_rate`
+        let empirical = EmpiricalRate::new(
+            vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+            vec![1.0, 1.0, 0.0, 0.0, 1.0, 1.0],
+        )
+        .unwrap();
+        assert_almost_eq!(empirical.infection_duration(), 5.0, 0.0);
     }
 }

--- a/src/rate_fns/rate_fn.rs
+++ b/src/rate_fns/rate_fn.rs
@@ -84,6 +84,8 @@ impl<T: ?Sized + InfectiousnessRateFn> InfectiousnessRateFn for ScaledRateFn<'_,
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
+    use statrs::assert_almost_eq;
+
     use crate::rate_fns::{
         rate_fn::{InfectiousnessRateFn, ScaledRateFn},
         ConstantRate,
@@ -138,5 +140,18 @@ mod tests {
         assert_eq!(scaled_rate_fn.inverse_cum_rate(4.0), Some(1.0));
         assert_eq!(scaled_rate_fn.inverse_cum_rate(8.0), Some(2.0));
         assert_eq!(scaled_rate_fn.inverse_cum_rate(11.0), None);
+    }
+
+    #[test]
+    fn test_scale_rate_fn_infection_duration() {
+        let rate_fn = ConstantRate::new(2.0, 5.0);
+        let scaled_rate_fn = ScaledRateFn {
+            base: &rate_fn,
+            scale: 2.0,
+            elapsed: 3.0,
+        };
+        assert_almost_eq!(scaled_rate_fn.infection_duration_remaining(0.0), 2.0, 0.0);
+        assert_almost_eq!(scaled_rate_fn.infection_duration_remaining(1.0), 1.0, 0.0);
+        assert_almost_eq!(scaled_rate_fn.infection_duration_remaining(3.0), -1.0, 0.0);
     }
 }

--- a/src/rate_fns/rate_fn.rs
+++ b/src/rate_fns/rate_fn.rs
@@ -24,7 +24,7 @@ pub trait InfectiousnessRateFn {
 
     /// Returns the remaining time of the infectiousness period at time `t`. Can return a negative
     /// number if the infectiousness period has already ended.
-    fn infection_duration_remaining(&self, t: f64) -> f64;
+    fn infection_duration(&self) -> f64;
 }
 
 /// A utility for scaling and shifting an infectiousness rate function
@@ -75,9 +75,9 @@ impl<T: ?Sized + InfectiousnessRateFn> InfectiousnessRateFn for ScaledRateFn<'_,
                 - self.elapsed,
         )
     }
-    /// Returns the remaining infectiousness period at `t + elapsed`.
-    fn infection_duration_remaining(&self, t: f64) -> f64 {
-        self.base.infection_duration_remaining(t + self.elapsed)
+    /// Returns the remaining infectiousness period at `elapsed`.
+    fn infection_duration(&self) -> f64 {
+        self.base.infection_duration() - self.elapsed
     }
 }
 
@@ -150,8 +150,6 @@ mod tests {
             scale: 2.0,
             elapsed: 3.0,
         };
-        assert_almost_eq!(scaled_rate_fn.infection_duration_remaining(0.0), 2.0, 0.0);
-        assert_almost_eq!(scaled_rate_fn.infection_duration_remaining(1.0), 1.0, 0.0);
-        assert_almost_eq!(scaled_rate_fn.infection_duration_remaining(3.0), -1.0, 0.0);
+        assert_almost_eq!(scaled_rate_fn.infection_duration(), 2.0, 0.0);
     }
 }

--- a/src/rate_fns/rate_fn.rs
+++ b/src/rate_fns/rate_fn.rs
@@ -21,6 +21,10 @@ pub trait InfectiousnessRateFn {
     /// E.g., Where t=day, `inverse_cum_rate(6.0)` -> 2.0 means that we would expect
     /// that it would take 2 days to infect 6 people
     fn inverse_cum_rate(&self, events: f64) -> Option<f64>;
+
+    /// Returns the remaining time of the infectiousness period at time `t`. Can return a negative
+    /// number if the infectiousness period has already ended.
+    fn infection_duration_remaining(&self, t: f64) -> f64;
 }
 
 /// A utility for scaling and shifting an infectiousness rate function
@@ -70,6 +74,10 @@ impl<T: ?Sized + InfectiousnessRateFn> InfectiousnessRateFn for ScaledRateFn<'_,
                 .inverse_cum_rate(events / self.scale + elapsed_cum_rate)?
                 - self.elapsed,
         )
+    }
+    /// Returns the remaining infectiousness period at `t + elapsed`.
+    fn infection_duration_remaining(&self, t: f64) -> f64 {
+        self.base.infection_duration_remaining(t + self.elapsed)
     }
 }
 

--- a/src/rate_fns/rate_fn.rs
+++ b/src/rate_fns/rate_fn.rs
@@ -151,5 +151,13 @@ mod tests {
             elapsed: 3.0,
         };
         assert_almost_eq!(scaled_rate_fn.infection_duration(), 2.0, 0.0);
+
+        // Show that changing `elapsed`` also changes the infection duration
+        let scaled_rate_fn = ScaledRateFn {
+            base: &rate_fn,
+            scale: 2.0,
+            elapsed: 2.0,
+        };
+        assert_almost_eq!(scaled_rate_fn.infection_duration(), 3.0, 0.0);
     }
 }

--- a/src/rate_fns/rate_fn_storage.rs
+++ b/src/rate_fns/rate_fn_storage.rs
@@ -62,8 +62,8 @@ mod tests {
         fn inverse_cum_rate(&self, _events: f64) -> Option<f64> {
             Some(1.0)
         }
-        fn infection_duration_remaining(&self, t: f64) -> f64 {
-            1.0 - t
+        fn infection_duration(&self) -> f64 {
+            1.0
         }
     }
 

--- a/src/rate_fns/rate_fn_storage.rs
+++ b/src/rate_fns/rate_fn_storage.rs
@@ -62,6 +62,9 @@ mod tests {
         fn inverse_cum_rate(&self, _events: f64) -> Option<f64> {
             Some(1.0)
         }
+        fn infection_duration_remaining(&self, t: f64) -> f64 {
+            1.0 - t
+        }
     }
 
     fn init_context() -> Context {


### PR DESCRIPTION
- Although infection duration is still specified as a global parameter, this structure enables each rate function type to have their own definition of infection duration and for each rate function instance to have a different value of the infection duration.
- If we switch to the structure in #62, infection duration can be specified for each rate function at input.
- This PR does not solve the problem of needing to model _symptom_ recovery, and a subsequent PR will introduce a `ClinicalDiseaseSymptomStatus` and tracker.