### PR TITLE
Update Ixa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ixa = "0.1.0"
+ixa = "0.1.1"
 csv = "1.3.1"
 tempfile = "3.19.1"
 statrs = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.5.21", features = ["derive"] }
-ctor = "0.2.9"
+ixa = "0.1.0"
 csv = "1.3.1"
-ixa = { git = "https://github.com/cdcgov/ixa.git", branch = "release" }
-ixa-derive = { git = "https://github.com/cdcgov/ixa", branch = "release" }
-paste = "1.0.15"
-rand = "0.8.5"
-tempfile = "3.14.0"
-statrs = "0.17.1"
+tempfile = "3.19.1"
+statrs = "0.18.0"
 serde = "1.0.217"
-serde_derive = "1.0.217"
 serde_json = "1.0.139"
 tinyset = "0.5.1"

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -44,11 +44,6 @@ fn schedule_recovery(context: &mut Context, person: PersonId) {
 /// - If `initial_infections` is greater than the population size.
 fn seed_infections(context: &mut Context, initial_infections: usize) -> Result<(), IxaError> {
     for _ in 0..initial_infections {
-        // Need to get the value of the derived person property first?
-        let _ = context.get_person_property(
-            context.sample_person(InfectionRng, ()).unwrap(),
-            InfectionStatus,
-        );
         let person = context.sample_person(
             InfectionRng,
             (InfectionStatus, InfectionStatusValue::Susceptible),

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -44,9 +44,11 @@ fn schedule_recovery(context: &mut Context, person: PersonId) {
 /// - If `initial_infections` is greater than the population size.
 fn seed_infections(context: &mut Context, initial_infections: usize) -> Result<(), IxaError> {
     for _ in 0..initial_infections {
-        // Need to get the value of the derived person property so that its entry in the person
-        // properties hash map is created prior to sampling...
-        // let _ = context.get_person_property(context.sample_person(InfectionRng, ()).unwrap(), InfectionStatus);
+        // Need to get the value of the derived person property first?
+        let _ = context.get_person_property(
+            context.sample_person(InfectionRng, ()).unwrap(),
+            InfectionStatus,
+        );
         let person = context.sample_person(
             InfectionRng,
             (InfectionStatus, InfectionStatusValue::Susceptible),


### PR DESCRIPTION
When switching to the version of Ixa on crates.io, I noticed that the stochastics changed. In particular, the bug referenced in #71 can have tests pass stochastically (hence we had not caught the problem), but now the stochastics have changed and the associated tests failed. I fixed the bug, but it's a curious observation that the stochastics changed.

I also noticed that we no longer needed `rand`, `paste`, and `ctor` manually in our `Cargo.toml` (which is what was causing the troubles that were fixed in https://github.com/CDCgov/ixa/pull/270), so potentially the two are related?