### PR TITLE
Simple category container and assignment

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,11 @@ mod transmission_report;
 pub mod utils;
 
 use infectiousness_manager::InfectionStatus;
-use symptom_progression::ClinicalSymptoms;
 use ixa::runner::run_with_args;
 use ixa::{ContextPeopleExt, ContextRandomExt, ContextReportExt};
 use parameters::{ContextParametersExt, Params};
 use population_loader::{Age, CensusTract};
+use symptom_progression::ClinicalSymptoms;
 
 // You must run this with a parameters file:
 // cargo run -- --config input/input.json

--- a/src/symptom_progression.rs
+++ b/src/symptom_progression.rs
@@ -129,7 +129,10 @@ fn schedule_symptoms(context: &mut Context, person: PersonId) {
 mod test {
     use std::path::PathBuf;
 
-    use super::{ClinicalCategoryExt, ClinicalCategoryPlugin, SymptomValue, ClinicalSymptoms, schedule_symptoms};
+    use super::{
+        schedule_symptoms, ClinicalCategoryExt, ClinicalCategoryPlugin, ClinicalSymptoms,
+        SymptomValue,
+    };
     use crate::{
         parameters::{GlobalParams, RateFnType},
         rate_fns::load_rate_fns,
@@ -192,6 +195,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::cast_lossless, clippy::cast_precision_loss)]
     fn test_schedule_symptoms() {
         let mut context = setup();
         let cat1_prop = 0.2;
@@ -206,8 +210,10 @@ mod test {
         }
         context.execute();
 
-        let cat1_count = context.query_people_count((ClinicalSymptoms, Some(SymptomValue::Category1)));
-        let cat2_count = context.query_people_count((ClinicalSymptoms, Some(SymptomValue::Category2)));
+        let cat1_count =
+            context.query_people_count((ClinicalSymptoms, Some(SymptomValue::Category1)));
+        let cat2_count =
+            context.query_people_count((ClinicalSymptoms, Some(SymptomValue::Category2)));
 
         let cat1_actual_prop = cat1_count as f64 / pop_size as f64;
         let cat2_actual_prop = cat2_count as f64 / pop_size as f64;

--- a/src/symptom_progression.rs
+++ b/src/symptom_progression.rs
@@ -1,6 +1,6 @@
 use ixa::{
-    define_person_property_with_default, define_rng, Context, ContextPeopleExt, ContextRandomExt,
-    IxaError, PersonPropertyChangeEvent, PersonId,
+    define_data_plugin, define_person_property_with_default, define_rng, Context, ContextPeopleExt,
+    ContextRandomExt, IxaError, PersonId, PersonPropertyChangeEvent,
 };
 use serde::Serialize;
 
@@ -13,16 +13,60 @@ pub enum SymptomValue {
     Category1,
     Category2,
     Category3,
-    Category4
+    Category4,
 }
 
-define_person_property_with_default!(
-    ClinicalSymptoms,
-    Option<SymptomValue>,
-    None
+define_person_property_with_default!(ClinicalSymptoms, Option<SymptomValue>, None);
+
+struct ClinicalCategoryContainer {
+    categories: Vec<SymptomValue>,
+    recovery_distributions: Vec<f64>,
+    incubation_distributions: Vec<f64>,
+}
+
+define_data_plugin!(
+    ClinicalCategoryPlugin,
+    ClinicalCategoryContainer,
+    ClinicalCategoryContainer {
+        categories: Vec::new(),
+        recovery_distributions: Vec::new(),
+        incubation_distributions: Vec::new()
+    }
 );
 
+pub trait ClinicalCategoryExt {
+    fn add_category(
+        &mut self,
+        category: SymptomValue,
+        recovery_distribution: f64,
+        incubation_distribution: f64,
+    ) -> usize;
+}
+
+impl ClinicalCategoryExt for Context {
+    fn add_category(
+        &mut self,
+        category: SymptomValue,
+
+        recovery_distribution: f64,
+        incubation_distribution: f64,
+    ) -> usize {
+        let container = self.get_data_container_mut(ClinicalCategoryPlugin);
+        container.categories.push(category);
+        container.recovery_distributions.push(recovery_distribution);
+        container
+            .incubation_distributions
+            .push(incubation_distribution);
+
+        container.categories.len() - 1
+    }
+}
+
 pub fn init(context: &mut Context) {
+    context.add_category(SymptomValue::Category1, 10.0, 5.0);
+    context.add_category(SymptomValue::Category2, 10.0, 5.0);
+    context.add_category(SymptomValue::Category3, 10.0, 5.0);
+    context.add_category(SymptomValue::Category4, 10.0, 5.0);
     // Save disease data for a person somewhere after infection
     // If symptomatic, choose one of the categories and make a plan to stop being symptomatic
     context.subscribe_to_event(
@@ -30,52 +74,45 @@ pub fn init(context: &mut Context) {
             if event.current == InfectionStatusValue::Infectious {
                 schedule_symptoms(context, event.person_id);
             }
-        }
+        },
     );
     context.subscribe_to_event(
         |context, event: PersonPropertyChangeEvent<ClinicalSymptoms>| {
-            match event.current  {
-                Some(_category) => schedule_recovery(context, event.person_id),
-                None => (),
+            if let Some(_category) = event.current {
+                schedule_recovery(context, event.person_id);
             }
-        }
+        },
     );
 }
 
 fn schedule_recovery(context: &mut Context, person: PersonId) {
     // Need to call symptom duration from a data plugin
     let symptom_duration = 10.0;
-    context.add_plan(context.get_current_time() + symptom_duration,
-        move | context| {
-            context.set_person_property(
-                person,
-                ClinicalSymptoms,
-                None 
-            );
-        }
+    context.add_plan(
+        context.get_current_time() + symptom_duration,
+        move |context| {
+            context.set_person_property(person, ClinicalSymptoms, None);
+        },
     );
 }
 
 fn schedule_symptoms(context: &mut Context, person: PersonId) {
     // Need to call incubation period from disease data plugin
     let incubation_period = 5.0;
-    let category = 
-        match context.sample_weighted(SymptomRng, &[0.1,0.4,0.3,0.2]) {
-            0 => Ok(SymptomValue::Category1),
-            1 => Ok(SymptomValue::Category2),
-            2 => Ok(SymptomValue::Category3),
-            3 => Ok(SymptomValue::Category4),
-            4_usize.. => Err(IxaError::IxaError("Error sampling".to_string())),
-        }.unwrap();
-    
-    context.add_plan(context.get_current_time() + incubation_period,
-        move | context| {
-            context.set_person_property(
-                person,
-                ClinicalSymptoms,
-                Some(category)                            
-            );
-        }
+    let category = match context.sample_weighted(SymptomRng, &[0.1, 0.4, 0.3, 0.2]) {
+        0 => Ok(SymptomValue::Category1),
+        1 => Ok(SymptomValue::Category2),
+        2 => Ok(SymptomValue::Category3),
+        3 => Ok(SymptomValue::Category4),
+        4_usize.. => Err(IxaError::IxaError("Error sampling".to_string())),
+    }
+    .unwrap();
+
+    context.add_plan(
+        context.get_current_time() + incubation_period,
+        move |context| {
+            context.set_person_property(person, ClinicalSymptoms, Some(category));
+        },
     );
 }
 
@@ -83,16 +120,14 @@ fn schedule_symptoms(context: &mut Context, person: PersonId) {
 mod test {
     use std::path::PathBuf;
 
-    use super::init;
+    use super::{ClinicalCategoryExt, ClinicalCategoryPlugin, SymptomValue};
     use crate::{
         parameters::{GlobalParams, RateFnType},
         rate_fns::load_rate_fns,
         Params,
     };
 
-    use ixa::{
-        Context, ContextGlobalPropertiesExt, ContextPeopleExt, ContextRandomExt, ExecutionPhase,
-    };
+    use ixa::{Context, ContextGlobalPropertiesExt, ContextRandomExt};
 
     fn setup() -> Context {
         let mut context = Context::new();
@@ -114,5 +149,35 @@ mod test {
             .unwrap();
         load_rate_fns(&mut context).unwrap();
         context
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn test_add_category() {
+        let mut context = setup();
+        //FAILURE: PeoplePlugin is not initialized; make sure you add a person before accessing properties
+        let category = context.add_category(SymptomValue::Category1, 1.0, 2.0);
+        assert_eq!(category, 0);
+        assert_eq!(
+            context
+                .get_data_container(ClinicalCategoryPlugin)
+                .unwrap()
+                .categories[0],
+            SymptomValue::Category1
+        );
+        assert_eq!(
+            context
+                .get_data_container(ClinicalCategoryPlugin)
+                .unwrap()
+                .recovery_distributions[0],
+            1.0
+        );
+        assert_eq!(
+            context
+                .get_data_container(ClinicalCategoryPlugin)
+                .unwrap()
+                .incubation_distributions[0],
+            2.0
+        );
     }
 }


### PR DESCRIPTION
Introduces a new data plugin for managing clinical categories and adding category-specific functionality for handling symptom progression.

Refactoring:

* [`src/symptom_progression.rs`](diffhunk://#diff-cbdf42c51de636fba82fdd41ef83934c9b10a79bcefe5ff202477528dc0020eaL16-R130): Introduced `ClinicalCategoryContainer` and `ClinicalCategoryPlugin` to manage clinical categories and their associated distributions. Added the `ClinicalCategoryExt` trait for extending the `Context` with methods to add categories similar to the `InfectiousnessRateExt` used to track infectiousness rates.
* [`src/symptom_progression.rs`](diffhunk://#diff-cbdf42c51de636fba82fdd41ef83934c9b10a79bcefe5ff202477528dc0020eaL16-R130): Modified the `init` function to initialize clinical categories and subscribe to events for managing symptoms and recovery.
