### PR TITLE
Made evaluate forecast assert statement match error message

### DIFF
--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -117,7 +117,7 @@ pub fn evaluate_forecast(
     let current_infectiousness = total_rate_fn.rate(elapsed_t);
 
     assert!(
-        (f64::abs(current_infectiousness - forecasted_total_infectiousness) <= f64::EPSILON),
+        (current_infectiousness <= forecasted_total_infectiousness),
         "Person {person_id}: Forecasted infectiousness must always be greater than or equal to current infectiousness. Current: {current_infectiousness}, Forecasted: {forecasted_total_infectiousness}"
     );
 


### PR DESCRIPTION
The `assert!` evaluation in comparing the current infectiousness with forecasted infectiousness works for checking rounding errors but doesn't provide the actual panic check we want for the evaluation. Changed here to keep the evaluation consistent. This `assert!` still panics for some forecasts that possess rounding errors.