### PR TITLE
Set R version in pre-commit to 4.4

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -22,4 +22,5 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       with:
         use-public-rspm: true
+        r-version: "4.4"
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Pre-commit is failing on open PRs. This is because Github actions is grabbing R 4.5, and for some reason this is causing an issue with getting the package `digest` installed in pre-commit. Reverting back to R 4.4 solves the problem. This is a documented issue on other CFA CDCGov repos.