### PR TITLE
Validate a new itinerary

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -369,7 +369,7 @@ mod test {
     }
 
     #[test]
-    fn test_duplicated_itinterary() {
+    fn test_duplicated_itinerary() {
         let mut context = Context::new();
         context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
 
@@ -388,7 +388,7 @@ mod test {
     }
 
     #[test]
-    fn test_feasible_itinterary() {
+    fn test_feasible_itinerary() {
         let mut context = Context::new();
         context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
 
@@ -404,7 +404,7 @@ mod test {
     }
 
     #[test]
-    fn test_add_itinterary() {
+    fn test_add_itinerary() {
         let mut context = Context::new();
         context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
 


### PR DESCRIPTION
## Summary
This PR introduces a validation method to check properties of a new itinerary. An existing check for duplicate itineraries has been added to this method and a new check for non-negative itinerary ratios has been added. A unit test checking the correct error is thrown for a negative itinerary ratio has been added.