### PR TITLE
Make tests pass and read in alpha values for settings module

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -22,4 +22,5 @@ jobs:
     - uses: r-lib/actions/setup-r@v2
       with:
         use-public-rspm: true
+        r-version: "4.4"
     - uses: pre-commit/action@v3.0.1

--- a/input/input.json
+++ b/input/input.json
@@ -4,6 +4,12 @@
     "seed": 123,
     "infectiousness_rate_fn": {"Constant": {"rate": 1.0, "duration": 5.0}},
     "initial_infections": 1,
+    "settings_properties": [
+      ["Home", 0.1],
+      ["Workplace", 0.1],
+      ["School", 0.1],
+      ["CensusTract", 0.1]
+    ],
     "report_period": 1.0,
     "synth_population_file": "input/people_test.csv"
   }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,4 +1,5 @@
 use ixa::{define_rng, people::Query, Context, ContextPeopleExt, ContextRandomExt, PersonId};
+use crate::settings::ContextSettingExt;
 
 define_rng!(ContactRng);
 
@@ -6,7 +7,13 @@ pub trait ContextContactExt {
     /// Returns a potential contact for the transmitter given a query of people
     /// properties, for example `(Alive, true)`.
     /// Returns None if there are no eligible contacts.
+    #[allow(dead_code)]
     fn get_contact<Q: Query>(&self, transmitter_id: PersonId, query: Q) -> Option<PersonId>;
+
+    /// Returns a potential contact from the transmitter give a pre-specified itinerary
+    /// Returns None if there aren't eligible contacts
+    // TODO: include a query
+    fn get_contact_from_settings(&self, transmitter_id: PersonId) -> Option<PersonId>;
 }
 
 impl ContextContactExt for Context {
@@ -26,6 +33,9 @@ impl ContextContactExt for Context {
                 possible_contacts[self.sample_range(ContactRng, 0..possible_contacts.len())];
         }
         Some(contact_id)
+    }    
+    fn get_contact_from_settings(&self, transmitter_id: PersonId) -> Option<PersonId> {
+        self.draw_contact_from_itinerary(transmitter_id)
     }
 }
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,5 +1,5 @@
-use ixa::{define_rng, people::Query, Context, ContextPeopleExt, ContextRandomExt, PersonId};
 use crate::settings::ContextSettingExt;
+use ixa::{define_rng, people::Query, Context, ContextPeopleExt, ContextRandomExt, PersonId};
 
 define_rng!(ContactRng);
 
@@ -33,7 +33,7 @@ impl ContextContactExt for Context {
                 possible_contacts[self.sample_range(ContactRng, 0..possible_contacts.len())];
         }
         Some(contact_id)
-    }    
+    }
     fn get_contact_from_settings(&self, transmitter_id: PersonId) -> Option<PersonId> {
         self.draw_contact_from_itinerary(transmitter_id)
     }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -33,7 +33,7 @@ impl ContextContactExt for Context {
                 possible_contacts[self.sample_range(ContactRng, 0..possible_contacts.len())];
         }
         Some(contact_id)
-    }    
+    }
     fn get_contact_from_settings(&self, transmitter_id: PersonId) -> Option<PersonId> {
         self.draw_contact_from_itinerary(transmitter_id)
     }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,6 +1,5 @@
 use crate::settings::ContextSettingExt;
 use ixa::{define_rng, people::Query, Context, ContextPeopleExt, ContextRandomExt, PersonId};
-use crate::settings::ContextSettingExt;
 
 define_rng!(ContactRng);
 
@@ -35,9 +34,6 @@ impl ContextContactExt for Context {
         }
         Some(contact_id)
     }    
-    fn get_contact_from_settings(&self, transmitter_id: PersonId) -> Option<PersonId> {
-        self.draw_contact_from_itinerary(transmitter_id)
-    }
     fn get_contact_from_settings(&self, transmitter_id: PersonId) -> Option<PersonId> {
         self.draw_contact_from_itinerary(transmitter_id)
     }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -94,6 +94,9 @@ mod test {
         },
         parameters::{ContextParametersExt, GlobalParams, Params, RateFnType},
         rate_fns::load_rate_fns,
+        settings::{
+            define_setting_type, ContextSettingExt, ItineraryEntry, SettingId, SettingProperties,
+        },
     };
 
     use super::{schedule_recovery, seed_infections};
@@ -119,12 +122,22 @@ mod test {
         context
     }
 
+    define_setting_type!(Test);
+    fn global_mixing_itinerary(context: &mut Context, alpha: f64) {
+        for i in context.query_people(()) {
+            let itinerary = vec![ItineraryEntry::new(&SettingId::<Test>::new(0), 1.0)];
+            context.add_itinerary(i, itinerary).unwrap();
+        }
+        context.register_setting_type(Test {}, SettingProperties { alpha });
+    }
+
     #[test]
     fn test_seed_infections() {
         let mut context = setup_context(0, 1.0);
         for _ in 0..10 {
             context.add_person(()).unwrap();
         }
+        global_mixing_itinerary(&mut context, 1.0);
         load_rate_fns(&mut context).unwrap();
         seed_infections(&mut context, 5);
         let infectious_count = context
@@ -139,6 +152,7 @@ mod test {
         for _ in 0..10 {
             context.add_person(()).unwrap();
         }
+        global_mixing_itinerary(&mut context, 1.0);
 
         init(&mut context).unwrap();
 
@@ -178,6 +192,7 @@ mod test {
         for _ in 0..=context.get_params().initial_infections {
             context.add_person(()).unwrap();
         }
+        global_mixing_itinerary(&mut context, 1.0);
 
         init(&mut context).unwrap();
 
@@ -216,7 +231,7 @@ mod test {
         // attempt happens quickly, that increases the chance we see another in 1.0 time units, and
         // because there is basically this compensating relationship between the time and the number
         // of events, they "cancel" each other out to give a uniform distribution (handwavingly).
-        let num_sims: u64 = 10000;
+        let num_sims: u64 = 20_000;
         let rate = 1.5;
         // We need the total infectiousness multiplier for the person.
         let mut total_infectiousness_multiplier = None;
@@ -237,6 +252,7 @@ mod test {
             load_rate_fns(&mut context).unwrap();
             // Add our infectious fellow.
             let infectious_person = context.add_person(()).unwrap();
+            global_mixing_itinerary(&mut context, 1.0);
             context.infect_person(infectious_person, None);
             // Get the total infectiousness multiplier for comparison to total number of infections.
             if total_infectiousness_multiplier.is_none() {
@@ -305,6 +321,7 @@ mod test {
         let mut context = setup_context(0, 0.0);
         load_rate_fns(&mut context).unwrap();
         let person = context.add_person(()).unwrap();
+
         seed_infections(&mut context, 1);
         // For later, we need to get the recovery time from the rate function.
         let recovery_time = context.get_person_rate_fn(person).infection_duration();

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -114,6 +114,7 @@ mod test {
             report_period: 1.0,
             synth_population_file: PathBuf::from("."),
             transmission_report_name: None,
+            settings_properties: vec![],
         };
         context.init_random(parameters.seed);
         context
@@ -252,7 +253,9 @@ mod test {
             load_rate_fns(&mut context).unwrap();
             // Add our infectious fellow.
             let infectious_person = context.add_person(()).unwrap();
+
             global_mixing_itinerary(&mut context, 1.0);
+
             context.infect_person(infectious_person, None);
             // Get the total infectiousness multiplier for comparison to total number of infections.
             if total_infectiousness_multiplier.is_none() {

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -6,9 +6,9 @@ use serde::Serialize;
 use statrs::distribution::Exp;
 
 use crate::{
-    contact::ContextContactExt, settings::ContextSettingExt,
-    population_loader::Alive,
+    contact::ContextContactExt,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, RateFnId, ScaledRateFn},
+    settings::ContextSettingExt,
 };
 
 #[derive(Serialize, PartialEq, Debug, Clone, Copy)]
@@ -49,7 +49,6 @@ define_derived_property!(
     }
 );
 
-
 /// Calculate the scaling factor that accounts for the total infectiousness
 /// for a person, given factors related to their environment, such as the number of people
 /// they come in contact with or how close they are.
@@ -64,7 +63,7 @@ pub fn calc_total_infectiousness_multiplier(context: &Context, person_id: Person
 pub fn max_total_infectiousness_multiplier(context: &Context, person_id: PersonId) -> f64 {
     // TODO: Max and current total infectiousness are the same for now until the notion of
     // being present in a setting is implemented
-    context.calculate_total_infectiousness_multiplier_for_person(person_id)    
+    context.calculate_total_infectiousness_multiplier_for_person(person_id)
 }
 
 define_rng!(ForecastRng);
@@ -223,7 +222,6 @@ mod test {
     use crate::{
         infectiousness_manager::{
             InfectionData, InfectionDataValue, InfectionStatus, InfectionStatusValue,
-            TOTAL_INFECTIOUSNESS_MULTIPLIER,
         },
         parameters::{GlobalParams, Params, RateFnType},
         rate_fns::load_rate_fns,
@@ -309,10 +307,7 @@ mod test {
     fn test_calc_total_infectiousness_multiplier() {
         let mut context = setup_context();
         let p1 = context.add_person(()).unwrap();
-        assert_eq!(
-            max_total_infectiousness_multiplier(&context, p1),
-            TOTAL_INFECTIOUSNESS_MULTIPLIER
-        );
+        assert_eq!(max_total_infectiousness_multiplier(&context, p1), 1.0);
     }
 
     #[test]
@@ -338,7 +333,7 @@ mod test {
         let p1 = context.add_person(()).unwrap();
         context.infect_person(p1, None);
 
-        let invalid_forecast = TOTAL_INFECTIOUSNESS_MULTIPLIER - 0.1;
+        let invalid_forecast = 1.0 - 0.1;
         evaluate_forecast(&mut context, p1, invalid_forecast);
     }
 

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -248,6 +248,7 @@ mod test {
                     report_period: 1.0,
                     synth_population_file: PathBuf::from("."),
                     transmission_report_name: None,
+                    settings_properties: vec![],
                 },
             )
             .unwrap();

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -345,11 +345,12 @@ mod test {
     }
 
     #[test]
-    #[should_panic = "Person 0: Forecasted infectiousness must always be greater than or equal to current infectiousness. Current: 0, Forecasted: 0.9"]
+    #[should_panic = "Person 0: Forecasted infectiousness must always be greater than or equal to current infectiousness. Current: 1, Forecasted: 0.9"]
     fn test_assert_evaluate_fails_when_forecast_smaller() {
         let mut context = setup_context();
         let p1 = context.add_person(()).unwrap();
         context.infect_person(p1, None);
+        let _ = context.add_person(()).unwrap();
 
         global_mixing_itinerary(&mut context, 1.0);
 

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use statrs::distribution::Exp;
 
 use crate::{
-    contact::ContextContactExt,
+    contact::ContextContactExt, settings::ContextSettingExt,
     population_loader::Alive,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, RateFnId, ScaledRateFn},
 };
@@ -49,24 +49,22 @@ define_derived_property!(
     }
 );
 
-const TOTAL_INFECTIOUSNESS_MULTIPLIER: f64 = 2.0;
 
 /// Calculate the scaling factor that accounts for the total infectiousness
 /// for a person, given factors related to their environment, such as the number of people
 /// they come in contact with or how close they are.
 /// This is used to scale the intrinsic infectiousness function of that person.
-pub fn calc_total_infectiousness_multiplier(_context: &Context, _person_id: PersonId) -> f64 {
-    // TODO<ryl8@cdc.gov> This is a placeholder until we have an implementation
-    // of settings and itineraries
-    TOTAL_INFECTIOUSNESS_MULTIPLIER
+pub fn calc_total_infectiousness_multiplier(context: &Context, person_id: PersonId) -> f64 {
+    // TODO: calculate current vs total infectiousness. This depends on interventions.
+    context.calculate_total_infectiousness_multiplier_for_person(person_id)
 }
 
 /// Calculate the maximum possible scaling factor for total infectiousness
 /// for a person, given information we know at the time of a forecast.
-pub fn max_total_infectiousness_multiplier(_context: &Context, _person_id: PersonId) -> f64 {
-    // TODO<ryl8@cdc.gov> This is a placeholder until we have an implementation
-    // of settings and itineraries
-    TOTAL_INFECTIOUSNESS_MULTIPLIER
+pub fn max_total_infectiousness_multiplier(context: &Context, person_id: PersonId) -> f64 {
+    // TODO: Max and current total infectiousness are the same for now until the notion of
+    // being present in a setting is implemented
+    context.calculate_total_infectiousness_multiplier_for_person(person_id)    
 }
 
 define_rng!(ForecastRng);

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -117,7 +117,7 @@ pub fn evaluate_forecast(
     let current_infectiousness = total_rate_fn.rate(elapsed_t);
 
     assert!(
-        (f64::abs(current_infectiousness - forecasted_total_infectiousness) <= f64::EPSILON),
+        (current_infectiousness <= forecasted_total_infectiousness),
         "Person {person_id}: Forecasted infectiousness must always be greater than or equal to current infectiousness. Current: {current_infectiousness}, Forecasted: {forecasted_total_infectiousness}"
     );
 

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -141,7 +141,8 @@ pub fn evaluate_forecast(
 /// Choose a the next contact for a given transmitter.
 /// Returns None if the contact is not susceptible.
 pub fn select_next_contact(context: &Context, person_id: PersonId) -> Option<PersonId> {
-    let next_contact = context.get_contact(person_id, ((Alive, true),))?;
+    //let next_contact = context.get_contact(person_id, ((Alive, true),))?;
+    let next_contact = context.get_contact_from_settings(person_id)?;
 
     if context.get_person_property(next_contact, InfectionStatus)
         != InfectionStatusValue::Susceptible

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ fn main() {
 
         // Load the synthetic population from the `synthetic_population_file`
         // specified in input.json.
+        settings::init(context);
         population_loader::init(context)?;
         context.index_property(Age);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use infectiousness_manager::InfectionStatus;
 use ixa::runner::run_with_args;
 use ixa::{ContextPeopleExt, ContextRandomExt, ContextReportExt};
 use parameters::{ContextParametersExt, Params};
-use population_loader::{Age, CensusTract};
+use population_loader::Age;
 
 // You must run this with a parameters file:
 // cargo run -- --config input/input.json
@@ -42,14 +42,13 @@ fn main() {
         context.add_periodic_report(
             "person_property_count",
             report_period,
-            (Age, CensusTract, InfectionStatus),
+            (Age, InfectionStatus),
         )?;
 
         // Load the synthetic population from the `synthetic_population_file`
         // specified in input.json.
         population_loader::init(context)?;
         context.index_property(Age);
-        context.index_property(CensusTract);
 
         infection_propagation_loop::init(context)?;
         transmission_report::init(context)?;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -23,6 +23,8 @@ pub struct Params {
     pub infectiousness_rate_fn: RateFnType,
     /// The period at which to report tabulated values
     pub report_period: f64,
+    /// Setting properties, currently only the transmission modifier alpha values for each setting
+    pub settings_properties: Vec<(String, f64)>,
     /// The path to the synthetic population file loaded in `population_loader`
     pub synth_population_file: PathBuf,
     /// The path to the transmission report file
@@ -89,6 +91,7 @@ mod test {
             report_period: 1.0,
             synth_population_file: PathBuf::from("."),
             transmission_report_name: None,
+            settings_properties: vec![],
         };
         context
             .set_global_property_value(GlobalParams, parameters)
@@ -113,6 +116,7 @@ mod test {
             report_period: 1.0,
             synth_population_file: PathBuf::from("."),
             transmission_report_name: None,
+            settings_properties: vec![],
         };
         let e = validate_inputs(&parameters).err();
         match e {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,6 +1,6 @@
-use std::fmt::Debug;
-use std::path::PathBuf;
+use std::{fmt::Debug, path::PathBuf};
 
+use crate::settings::CoreSettingsTypes;
 use ixa::{define_global_property, ContextGlobalPropertiesExt, IxaError};
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +24,7 @@ pub struct Params {
     /// The period at which to report tabulated values
     pub report_period: f64,
     /// Setting properties, currently only the transmission modifier alpha values for each setting
-    pub settings_properties: Vec<(String, f64)>,
+    pub settings_properties: Vec<(CoreSettingsTypes, f64)>,
     /// The path to the synthetic population file loaded in `population_loader`
     pub synth_population_file: PathBuf,
     /// The path to the transmission report file

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -8,7 +8,8 @@ use std::path::PathBuf;
 
 use crate::parameters::{ContextParametersExt, Params};
 use crate::settings::{
-    CensusTract, ContextSettingExt, Home, ItineraryEntry, School, SettingId, SettingProperties, Workplace
+    CensusTract, ContextSettingExt, Home, ItineraryEntry, School, SettingId, SettingProperties,
+    Workplace,
 };
 
 #[derive(Deserialize, Debug)]
@@ -23,15 +24,6 @@ pub struct PeopleRecord<'a> {
 define_person_property!(Age, u8);
 define_person_property_with_default!(Alive, bool, true);
 
-
-fn option_from_string(s: &str) -> Option<usize> {
-    if s.is_empty() {
-        None
-    } else {
-        Some(s.parse().unwrap())
-    }
-}
-
 fn create_person_from_record(
     context: &mut Context,
     person_record: &PeopleRecord,
@@ -43,20 +35,29 @@ fn create_person_from_record(
     let workplace_string: String = String::from_utf8(person_record.workplaceId.to_owned())?;
 
     // TODO: itinerary ratios should come from parameters
-    itinerary_person.push(ItineraryEntry::new(&SettingId::<Home>::new(home_id.parse()?), 0.25));
+    itinerary_person.push(ItineraryEntry::new(
+        &SettingId::<Home>::new(home_id.parse()?),
+        0.25,
+    ));
     if !school_string.is_empty() {
-        itinerary_person.push(ItineraryEntry::new(&SettingId::<School>::new(school_string.parse()?), 0.25));
+        itinerary_person.push(ItineraryEntry::new(
+            &SettingId::<School>::new(school_string.parse()?),
+            0.25,
+        ));
     }
     if !workplace_string.is_empty() {
-        itinerary_person.push(ItineraryEntry::new(&SettingId::<Workplace>::new(workplace_string.parse()?), 0.25));
+        itinerary_person.push(ItineraryEntry::new(
+            &SettingId::<Workplace>::new(workplace_string.parse()?),
+            0.25,
+        ));
     }
-    itinerary_person.push(ItineraryEntry::new(&SettingId::<CensusTract>::new(tract.parse()?), 0.25));
-    
-   
-    let person_id = context.add_person(
-        (Age, person_record.age)
-    )?;
-    
+    itinerary_person.push(ItineraryEntry::new(
+        &SettingId::<CensusTract>::new(tract.parse()?),
+        0.25,
+    ));
+
+    let person_id = context.add_person((Age, person_record.age))?;
+
     context.add_itinerary(person_id, itinerary_person)?;
 
     Ok(())
@@ -76,7 +77,8 @@ fn load_synth_population(context: &mut Context, synth_input_file: PathBuf) -> Re
 
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
     let Params {
-        synth_population_file, ..
+        synth_population_file,
+        ..
     } = context.get_params().clone();
 
     // TODO: These properties should come from somewhere and
@@ -114,21 +116,28 @@ mod test {
         let synth_file = persist_tmp_csv(&input);
         load_synth_population(&mut context, synth_file).unwrap();
         let age = [43, 42];
-        let tract = [36_093_033_102, 36_093_033_102];
         let home_id = [360_930_331_020_001, 360_930_331_020_002];
+        let census_tract_id = 36_093_033_102;
 
         assert_eq!(context.get_current_population(), 2);
 
         for i in 0..1 {
+            assert_eq!(1, context.query_people_count((Age, age[i])));
             assert_eq!(
                 1,
-                context.query_people_count((
-                    (Age, age[i]),
-                    (CensusTractId, tract[i]),
-                    (Household, home_id[i]),
-                ))
+                context
+                    .get_setting_members::<Home>(SettingId::<Home>::new(home_id[i]))
+                    .unwrap()
+                    .len()
             );
         }
+        assert_eq!(
+            2,
+            context
+                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(census_tract_id))
+                .unwrap()
+                .len()
+        );
     }
 
     #[test]
@@ -152,20 +161,34 @@ mod test {
         let age = [43, 42];
         let school_id = [1, 2];
         let home_id = [360_930_331_020_001, 360_930_331_020_002];
+        let census_tract_id = 36_093_033_102;
 
         assert_eq!(context.get_current_population(), 2);
 
         for i in 0..1 {
+            assert_eq!(1, context.query_people_count((Age, age[i])));
             assert_eq!(
                 1,
-                context.query_people_count((
-                    (Age, age[i]),
-                    (SchoolId, Some(school_id[i])),
-                    (Household, home_id[i]),
-                    (WorkplaceId, None)
-                ))
+                context
+                    .get_setting_members::<School>(SettingId::<School>::new(school_id[i]))
+                    .unwrap()
+                    .len()
+            );
+            assert_eq!(
+                1,
+                context
+                    .get_setting_members::<Home>(SettingId::<Home>::new(home_id[i]))
+                    .unwrap()
+                    .len()
             );
         }
+        assert_eq!(
+            2,
+            context
+                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(census_tract_id))
+                .unwrap()
+                .len()
+        );
     }
 
     #[test]
@@ -179,19 +202,33 @@ mod test {
         let age = [43, 42];
         let workplace_id = [1, 2];
         let home_id = [360_930_331_020_001, 360_930_331_020_002];
+        let census_tract_id = 36_093_033_102;
 
         assert_eq!(context.get_current_population(), 2);
 
         for i in 0..1 {
+            assert_eq!(1, context.query_people_count(((Age, age[i]),)));
             assert_eq!(
                 1,
-                context.query_people_count((
-                    (Age, age[i]),
-                    (Household, home_id[i]),
-                    (SchoolId, None),
-                    (WorkplaceId, Some(workplace_id[i]))
-                ))
+                context
+                    .get_setting_members::<Workplace>(SettingId::<Workplace>::new(workplace_id[i]))
+                    .unwrap()
+                    .len()
+            );
+            assert_eq!(
+                1,
+                context
+                    .get_setting_members::<Home>(SettingId::<Home>::new(home_id[i]))
+                    .unwrap()
+                    .len()
             );
         }
+        assert_eq!(
+            2,
+            context
+                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(census_tract_id))
+                .unwrap()
+                .len()
+        );
     }
 }

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 
 use crate::parameters::{ContextParametersExt, Params};
 use crate::settings::{
-    CensusTract, ContextSettingExt, Home, ItineraryEntry, School, SettingId, SettingProperties,
-    Workplace,
+    CensusTract, ContextSettingExt, Home, ItineraryEntry, School, SettingId,
+    Workplace
 };
 
 #[derive(Deserialize, Debug)]
@@ -80,13 +80,6 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
         synth_population_file,
         ..
     } = context.get_params().clone();
-
-    // TODO: These properties should come from somewhere and
-    // registering setting type should look different with expandable setting properties
-    context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
-    context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
-    context.register_setting_type(Workplace {}, SettingProperties { alpha: 0.05 });
-    context.register_setting_type(School {}, SettingProperties { alpha: 0.01 });
 
     load_synth_population(context, synth_population_file.clone())?;
     Ok(())

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -8,8 +8,7 @@ use std::path::PathBuf;
 
 use crate::parameters::{ContextParametersExt, Params};
 use crate::settings::{
-    CensusTract, ContextSettingExt, Home, ItineraryEntry, School, SettingId,
-    Workplace
+    CensusTract, ContextSettingExt, Home, ItineraryEntry, School, SettingId, Workplace,
 };
 
 #[derive(Deserialize, Debug)]

--- a/src/rate_fns/rate_fn_storage.rs
+++ b/src/rate_fns/rate_fn_storage.rs
@@ -168,6 +168,7 @@ mod tests {
             report_period: 1.0,
             synth_population_file: PathBuf::from("."),
             transmission_report_name: None,
+            settings_properties: vec![],
         };
         context
             .set_global_property_value(GlobalParams, parameters)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,11 +1,12 @@
+use crate::parameters::{ContextParametersExt, Params};
 use ixa::people::PersonId;
 use ixa::{define_data_plugin, define_rng, Context, ContextRandomExt, IxaError};
+use serde::{Deserialize, Serialize};
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::marker::PhantomData;
-use crate::parameters::{ContextParametersExt, Params};
 
 define_rng!(SettingsRng);
 
@@ -124,6 +125,14 @@ define_setting_type!(Home);
 define_setting_type!(CensusTract);
 define_setting_type!(School);
 define_setting_type!(Workplace);
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum CoreSettingsTypes {
+    Home,
+    CensusTract,
+    School,
+    Workplace,
+}
 
 define_data_plugin!(
     SettingDataPlugin,
@@ -332,18 +341,27 @@ impl ContextSettingExt for Context {
 }
 
 pub fn init(context: &mut Context) {
-    let &Params {
+    let Params {
         settings_properties,
         ..
     } = context.get_params();
 
+    let settings_properties = settings_properties.clone();
+
     for (setting_name, alpha) in settings_properties {
-        match setting_name.as_ref() {
-            "Home" => context.register_setting_type(Home {}, SettingProperties { alpha }),
-            "CensusTract" => context.register_setting_type(CensusTract {}, SettingProperties { alpha }),
-            "School" => context.register_setting_type(School {}, SettingProperties { alpha }),
-            "Workplace" => context.register_setting_type(Workplace {}, SettingProperties { alpha }),
-            _ => panic!("Unknown setting type: {}", setting_name),
+        match setting_name {
+            CoreSettingsTypes::Home => {
+                context.register_setting_type(Home {}, SettingProperties { alpha });
+            }
+            CoreSettingsTypes::CensusTract => {
+                context.register_setting_type(CensusTract {}, SettingProperties { alpha });
+            }
+            CoreSettingsTypes::School => {
+                context.register_setting_type(School {}, SettingProperties { alpha });
+            }
+            CoreSettingsTypes::Workplace => {
+                context.register_setting_type(Workplace {}, SettingProperties { alpha });
+            }
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::marker::PhantomData;
+use crate::parameters::{ContextParametersExt, Params};
 
 define_rng!(SettingsRng);
 
@@ -326,6 +327,23 @@ impl ContextSettingExt for Context {
             )
         } else {
             None
+        }
+    }
+}
+
+pub fn init(context: &mut Context) {
+    let &Params {
+        settings_properties,
+        ..
+    } = context.get_params();
+
+    for (setting_name, alpha) in settings_properties {
+        match setting_name.as_ref() {
+            "Home" => context.register_setting_type(Home {}, SettingProperties { alpha }),
+            "CensusTract" => context.register_setting_type(CensusTract {}, SettingProperties { alpha }),
+            "School" => context.register_setting_type(School {}, SettingProperties { alpha }),
+            "Workplace" => context.register_setting_type(Workplace {}, SettingProperties { alpha }),
+            _ => panic!("Unknown setting type: {}", setting_name),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,7 +11,7 @@ define_rng!(SettingsRng);
 // This is not the most flexible structure but would work for now
 #[derive(Debug, Clone, Copy)]
 pub struct SettingProperties {
-    alpha: f64,
+    pub alpha: f64,
 }
 
 pub trait SettingType {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -134,40 +134,6 @@ pub enum CoreSettingsTypes {
     Workplace,
 }
 
-// Define a home setting
-#[derive(Default, Debug, Hash, Eq, PartialEq)]
-pub struct School {}
-
-impl SettingType for School {
-    // Read members and setting_properties as arguments
-    fn calculate_multiplier(
-        &self,
-        members: &[PersonId],
-        setting_properties: SettingProperties,
-    ) -> f64 {
-        let n_members = members.len();
-        #[allow(clippy::cast_precision_loss)]
-        ((n_members - 1) as f64).powf(setting_properties.alpha)
-    }
-}
-
-// Define a home setting
-#[derive(Default, Debug, Hash, Eq, PartialEq)]
-pub struct Workplace {}
-
-impl SettingType for Workplace {
-    // Read members and setting_properties as arguments
-    fn calculate_multiplier(
-        &self,
-        members: &[PersonId],
-        setting_properties: SettingProperties,
-    ) -> f64 {
-        let n_members = members.len();
-        #[allow(clippy::cast_precision_loss)]
-        ((n_members - 1) as f64).powf(setting_properties.alpha)
-    }
-}
-
 define_data_plugin!(
     SettingDataPlugin,
     SettingDataContainer,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -47,7 +47,7 @@ pub struct ItineraryEntry {
 
 #[allow(dead_code)]
 impl ItineraryEntry {
-    fn new<T: SettingType>(setting_id: &SettingId<T>, ratio: f64) -> ItineraryEntry {
+    pub fn new<T: SettingType>(setting_id: &SettingId<T>, ratio: f64) -> ItineraryEntry {
         ItineraryEntry {
             setting_type: TypeId::of::<T>(),
             setting_id: setting_id.id,
@@ -118,6 +118,40 @@ impl SettingType for Home {
 #[derive(Default, Debug, Hash, Eq, PartialEq)]
 pub struct CensusTract {}
 impl SettingType for CensusTract {
+    fn calculate_multiplier(
+        &self,
+        members: &[PersonId],
+        setting_properties: SettingProperties,
+    ) -> f64 {
+        let n_members = members.len();
+        #[allow(clippy::cast_precision_loss)]
+        ((n_members - 1) as f64).powf(setting_properties.alpha)
+    }
+}
+
+// Define a home setting
+#[derive(Default, Debug, Hash, Eq, PartialEq)]
+pub struct School {}
+
+impl SettingType for School {
+    // Read members and setting_properties as arguments
+    fn calculate_multiplier(
+        &self,
+        members: &[PersonId],
+        setting_properties: SettingProperties,
+    ) -> f64 {
+        let n_members = members.len();
+        #[allow(clippy::cast_precision_loss)]
+        ((n_members - 1) as f64).powf(setting_properties.alpha)
+    }
+}
+
+// Define a home setting
+#[derive(Default, Debug, Hash, Eq, PartialEq)]
+pub struct Workplace {}
+
+impl SettingType for Workplace {
+    // Read members and setting_properties as arguments
     fn calculate_multiplier(
         &self,
         members: &[PersonId],

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -98,16 +98,17 @@ impl SettingDataContainer {
     }
 }
 
+#[macro_export]
 macro_rules! define_setting_type {
     ($name:ident) => {
         #[derive(Default, Debug, Hash, Eq, PartialEq)]
         pub struct $name {}
 
-        impl SettingType for $name {
+        impl $crate::settings::SettingType for $name {
             fn calculate_multiplier(
                 &self,
-                members: &[PersonId],
-                setting_properties: SettingProperties,
+                members: &[ixa::PersonId],
+                setting_properties: $crate::settings::SettingProperties,
             ) -> f64 {
                 let n_members = members.len();
                 #[allow(clippy::cast_precision_loss)]
@@ -116,6 +117,7 @@ macro_rules! define_setting_type {
         }
     };
 }
+pub use define_setting_type;
 
 define_setting_type!(Home);
 define_setting_type!(CensusTract);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -98,70 +98,29 @@ impl SettingDataContainer {
     }
 }
 
-// Define a home setting
-#[derive(Default, Debug, Hash, Eq, PartialEq)]
-pub struct Home {}
+macro_rules! define_setting_type {
+    ($name:ident) => {
+        #[derive(Default, Debug, Hash, Eq, PartialEq)]
+        pub struct $name {}
 
-impl SettingType for Home {
-    // Read members and setting_properties as arguments
-    fn calculate_multiplier(
-        &self,
-        members: &[PersonId],
-        setting_properties: SettingProperties,
-    ) -> f64 {
-        let n_members = members.len();
-        #[allow(clippy::cast_precision_loss)]
-        ((n_members - 1) as f64).powf(setting_properties.alpha)
-    }
+        impl SettingType for $name {
+            fn calculate_multiplier(
+                &self,
+                members: &[PersonId],
+                setting_properties: SettingProperties,
+            ) -> f64 {
+                let n_members = members.len();
+                #[allow(clippy::cast_precision_loss)]
+                ((n_members - 1) as f64).powf(setting_properties.alpha)
+            }
+        }
+    };
 }
 
-#[derive(Default, Debug, Hash, Eq, PartialEq)]
-pub struct CensusTract {}
-impl SettingType for CensusTract {
-    fn calculate_multiplier(
-        &self,
-        members: &[PersonId],
-        setting_properties: SettingProperties,
-    ) -> f64 {
-        let n_members = members.len();
-        #[allow(clippy::cast_precision_loss)]
-        ((n_members - 1) as f64).powf(setting_properties.alpha)
-    }
-}
-
-// Define a home setting
-#[derive(Default, Debug, Hash, Eq, PartialEq)]
-pub struct School {}
-
-impl SettingType for School {
-    // Read members and setting_properties as arguments
-    fn calculate_multiplier(
-        &self,
-        members: &[PersonId],
-        setting_properties: SettingProperties,
-    ) -> f64 {
-        let n_members = members.len();
-        #[allow(clippy::cast_precision_loss)]
-        ((n_members - 1) as f64).powf(setting_properties.alpha)
-    }
-}
-
-// Define a home setting
-#[derive(Default, Debug, Hash, Eq, PartialEq)]
-pub struct Workplace {}
-
-impl SettingType for Workplace {
-    // Read members and setting_properties as arguments
-    fn calculate_multiplier(
-        &self,
-        members: &[PersonId],
-        setting_properties: SettingProperties,
-    ) -> f64 {
-        let n_members = members.len();
-        #[allow(clippy::cast_precision_loss)]
-        ((n_members - 1) as f64).powf(setting_properties.alpha)
-    }
-}
+define_setting_type!(Home);
+define_setting_type!(CensusTract);
+define_setting_type!(School);
+define_setting_type!(Workplace);
 
 define_data_plugin!(
     SettingDataPlugin,

--- a/src/transmission_report.rs
+++ b/src/transmission_report.rs
@@ -105,6 +105,7 @@ mod test {
                 "infectiousness_rate_fn": {"Constant": {"rate": 1.0, "duration": 5.0}},
                 "initial_infections": 1,
                 "report_period": 1.0,
+                "settings_properties": [],
                 "synth_population_file": "input/people_test.csv"
                 }
             }
@@ -124,6 +125,7 @@ mod test {
                 "infectiousness_rate_fn": {"Constant": {"rate": 1.0, "duration": 5.0}},
                 "initial_infections": 1,
                 "report_period": 1.0,
+                "settings_properties": [],
                 "synth_population_file": "input/people_test.csv",
                 "transmission_report_name": "output.csv"
                 }
@@ -145,6 +147,7 @@ mod test {
                 "infectiousness_rate_fn": {"Constant": {"rate": 1.0, "duration": 5.0}},
                 "initial_infections": 1,
                 "report_period": 1.0,
+                "settings_properties": [],
                 "synth_population_file": "input/people_test.csv",
                 "transmission_report_name": "output.csv"
                 }


### PR DESCRIPTION
Integrating settings-based properties by including a global mixing helper function in test modules and defining a macro for implementing SettingType for arbitrary names. Includes adjustments to read in alpha values (and future `SettingProperties`) in the parameter input.json.

### Integration of settings-based properties:
* Added a new `settings_properties` field to the `Params` struct to allow dynamic configuration of transmission modifiers for different settings (e.g., Home, Workplace, School, CensusTract). These draw from an introduced `enum` `CoreSettingsTypes` defined in the `settings.rs`
* Refactored `population_loader.rs` to remove hardcoded setting properties and ensure itineraries are dynamically created based on input parameters. Moved itinerary intialization into `settings.rs`

### Test coverage:
* Introduced the `global_mixing_itinerary` function in test modules to dynamically add itineraries and register setting types for testing purposes.
* Updated all infection loop test cases to validate the behavior of the new `settings_properties` field and ensure consistent handling of cases lacking spatial structure

### Code cleanup and refactoring:
* Removed redundant code by writing a macro `define_setting_type`

### To Do
* [ ] Read in itinerary values dynamically
