### PR TITLE
Setting validation 

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -146,7 +146,9 @@ mod test {
             .set_global_property_value(GlobalParams, parameters)
             .unwrap();
 
-        context.register_setting_type(HomogeneousMixing {}, SettingProperties { alpha });
+        context
+            .register_setting_type(HomogeneousMixing {}, SettingProperties { alpha })
+            .unwrap();
         context
     }
 

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -70,7 +70,9 @@ define_rng!(ForecastRng);
 
 // Infection attempt function for a context and given `PersonId`
 pub fn infection_attempt(context: &Context, person_id: PersonId) -> Option<PersonId> {
-    let next_contact = context.draw_contact_from_transmitter_itinerary(person_id, (Alive, true))?;
+    let next_contact = context
+        .draw_contact_from_transmitter_itinerary(person_id, (Alive, true))
+        .unwrap()?;
     match context.get_person_property(next_contact, InfectionStatus) {
         InfectionStatusValue::Susceptible => Some(next_contact),
         _ => None,

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -262,7 +262,9 @@ mod test {
             )
             .unwrap();
         load_rate_fns(&mut context).unwrap();
-        context.register_setting_type(HomogeneousMixing {}, SettingProperties { alpha: 1.0 });
+        context
+            .register_setting_type(HomogeneousMixing {}, SettingProperties { alpha: 1.0 })
+            .unwrap();
         context
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -219,6 +219,7 @@ impl ContextSettingInternalExt for Context {
                     "Attempting contact outside of group membership",
                 ));
             }
+            // The setting has one person in it -- this person
             if members.len() == 1 {
                 return Ok(None);
             }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -720,7 +720,6 @@ mod test {
 
     #[test]
     fn test_setting_multiplier() {
-        // TODO: if setting not registered, shouldn't be able to register people to setting
         let mut context = Context::new();
         let _ = context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
         for s in 0..5 {
@@ -811,7 +810,6 @@ mod test {
     fn test_get_contact_from_setting() {
         // Register two people to a setting and make sure that the person chosen is the other one
         // Attempt to draw a contact from a setting with only the person trying to get a contact
-        // TODO: What happens if the person isn't registered in the setting?
         let mut context = Context::new();
         context.init_random(42);
         context

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -827,6 +827,22 @@ mod test {
         assert!(context
             .get_contact(person_a, SettingId::<CensusTract>::new(0), ())
             .is_none());
+
+        let person_c = context.add_person(()).unwrap();
+        let itinerary_c = vec![ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5)];
+        let _ = context.add_itinerary(person_c, itinerary_c);
+
+        assert!(context
+            .get_contact::<CensusTract>(person_b, SettingId::<CensusTract>::new(0))
+            .is_none());
+
+        let person_c = context.add_person(()).unwrap();
+        let itinerary_c = vec![ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5)];
+        let _ = context.add_itinerary(person_c, itinerary_c);
+
+        assert!(context
+            .get_contact::<CensusTract>(person_b, SettingId::<CensusTract>::new(0))
+            .is_none());
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -817,11 +817,11 @@ mod test {
         let itinerary_b = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
         let _ = context.add_itinerary(person_a, itinerary_a);
         let _ = context.add_itinerary(person_b, itinerary_b);
-
         assert_eq!(
             person_b,
             context
                 .get_contact(person_a, SettingId::<Home>::new(0), ())
+                .unwrap()
                 .unwrap()
         );
         assert!(context
@@ -839,10 +839,19 @@ mod test {
         let person_c = context.add_person(()).unwrap();
         let itinerary_c = vec![ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5)];
         let _ = context.add_itinerary(person_c, itinerary_c);
-
-        assert!(context
-            .get_contact::<CensusTract>(person_b, SettingId::<CensusTract>::new(0))
-            .is_none());
+        let e = context
+            .get_contact(person_b, SettingId::<CensusTract>::new(0))
+            .err();
+        match e {
+            Some(IxaError::IxaError(msg)) => {
+                assert_eq!(msg, "Attempting contact in invalid setting");
+            }
+            Some(ue) => panic!(
+                "Expected an error attempting contact in invalid setting. Instead got: {:?}",
+                ue.to_string()
+            ),
+            None => panic!("Expected an error. Instead, validation passed with no errors."),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR addresses three TODO statements documented in issues #103, #105, and #107. The checks largely involve examining the contents of the `SettingsDataContainer` to observe if setting types are registered. 

## What's new
- A new trait extension, `validate_setting_registration` was added to validate setting type registration. 
- The `getting_setting_properties` trait extension is modified to return a `Result<SettingProperties, IxaError>
- Three new tests were added.

## Questions
-  Is there a way to call `self.validate_setting_registration` from within `get_setting_properties`?
- Should the solution to issue #105 throw an `IxaError` or just return none? 

## Updates After Rebasing

- This PR addresses an additional TODO statement documented in issue #114.
- The validation of settings requires that they be registered before individuals can be added to itineraries which have those settings. This meant that three tests in the population loader require settings to be initialized. It also meant that settings has to be initialized prior to the population loader in main. 