### PR TITLE
Fixed transmission report

### DIFF
--- a/input/input.json
+++ b/input/input.json
@@ -12,6 +12,7 @@
     ],
     "itinerary_fn_type": "SplitEvenly",
     "report_period": 1.0,
-    "synth_population_file": "input/people_test.csv"
+    "synth_population_file": "input/people_test.csv",
+    "transmission_report_name": "transmission_report.csv"
   }
 }


### PR DESCRIPTION
- Refactored the `record_transmission_event` function and updated the event subscription logic to ensure proper handling of infection data.
- Added a new `transmission_report_name` parameter to specify the output file name for the transmission report.