### PR TITLE
increase allowable integers for ids

### DIFF
--- a/src/rate_fns/rate_fn_storage.rs
+++ b/src/rate_fns/rate_fn_storage.rs
@@ -73,7 +73,7 @@ pub fn load_rate_fns(context: &mut Context) -> Result<(), IxaError> {
 
 #[derive(Deserialize)]
 pub struct EmpiricalRateFnRecord {
-    id: u8,
+    id: u32,
     time: f64,
     value: f64,
 }


### PR DESCRIPTION
In the `EmpiricalRateFnRecord` struct, the variable `id` was forced to be an 8-bit unsigned integer, which precluded simulations drawing from more than 256 empirical rate functions. This PR revises it to be a 32-bit unsigned integer. 