### PR TITLE
Separating the infection attempt process

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -4,6 +4,7 @@ use crate::infectiousness_manager::{
 };
 use crate::parameters::{ContextParametersExt, Params};
 use crate::rate_fns::rate_fn_storage::load_rate_fns;
+use crate::settings::ContextSettingExt;
 use ixa::{
     define_rng, trace, Context, ContextPeopleExt, IxaError, PersonId, PersonPropertyChangeEvent,
 };
@@ -19,9 +20,14 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
         context.add_plan(next_time, move |context| {
             // TODO<ryl8@cc.gov>: We will choose a setting here
             if evaluate_forecast(context, person, forecasted_total_infectiousness) {
-                if let Some(next_contact) = infection_attempt(context, person) {
-                    trace!("Person {person}: Forecast accepted, infecting {next_contact}");
-                    context.infect_person(next_contact, Some(person));
+                if let Some((setting_type, setting_id)) = context.get_setting_for_contact(person) {
+                    trace!("Person {person}: Forecast accepted, setting {setting_id}");
+                    if let Some(next_contact) =
+                        infection_attempt(context, person, setting_type, setting_id)
+                    {
+                        trace!("Person {person}: Forecast accepted, infecting {next_contact}");
+                        context.infect_person(next_contact, Some(person));
+                    }
                 }
             }
             // Continue scheduling forecasts until the person recovers.

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -8,7 +8,7 @@ use statrs::distribution::Exp;
 use crate::{
     population_loader::Alive,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, RateFnId, ScaledRateFn},
-    settings::ContextSettingExt,
+    settings::{ContextSettingExt, SettingType},
 };
 
 #[derive(Serialize, PartialEq, Debug, Clone, Copy)]
@@ -69,9 +69,14 @@ pub fn max_total_infectiousness_multiplier(context: &Context, person_id: PersonI
 define_rng!(ForecastRng);
 
 // Infection attempt function for a context and given `PersonId`
-pub fn infection_attempt(context: &Context, person_id: PersonId) -> Option<PersonId> {
+pub fn infection_attempt(
+    context: &Context,
+    person_id: PersonId,
+    setting_type: &dyn SettingType,
+    setting_id: usize,
+) -> Option<PersonId> {
     let next_contact = context
-        .draw_contact_from_transmitter_itinerary(person_id, (Alive, true))
+        .get_contact(person_id, setting_type, setting_id, (Alive, true))
         .unwrap()?;
     match context.get_person_property(next_contact, InfectionStatus) {
         InfectionStatusValue::Susceptible => Some(next_contact),


### PR DESCRIPTION
This PR addresses issue #101. The infection propagation loop is updated to separate the contents of `schedule_next_forecasted_infection` to first select a setting where the contact will occur. This returns a setting type and setting id. These two values are then passed to the modified `get_contact` method. This method extracts the `TypeId` from the setting type and calls the `get_contact_internal` method as before.  Tests were modified in the setting module to include tests for both selecting the setting and selecting the contact for setting.