### PR TITLE
Refactor places that require setting location to take `SettingId` rather than a tuple

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -20,13 +20,14 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
         context.add_plan(next_time, move |context| {
             // TODO<ryl8@cc.gov>: We will choose a setting here
             if evaluate_forecast(context, person, forecasted_total_infectiousness) {
-                if let Some((setting_type, setting_id)) = context.get_setting_for_contact(person) {
-                    let str_setting = setting_type.get_name();
+                if let Some(setting_id) = context.get_setting_for_contact(person) {
+                    let str_setting = setting_id.setting_type.get_name();
+                    let id = setting_id.id;
                     if let Some(next_contact) =
-                        infection_attempt(context, person, setting_type, setting_id)
+                        infection_attempt(context, person, setting_id)
                     {
-                        trace!("Person {person}: Forecast accepted, setting type {str_setting} {setting_id}, infecting {next_contact}");
-                        context.infect_person(next_contact, Some(person), Some(str_setting), Some(setting_id));
+                        trace!("Person {person}: Forecast accepted, setting type {str_setting} {id}, infecting {next_contact}");
+                        context.infect_person(next_contact, Some(person), Some(str_setting), Some(id));
                     }
                 }
             }
@@ -131,7 +132,7 @@ mod test {
         person_id: PersonId,
     ) -> Result<(), IxaError> {
         let itinerary = vec![ItineraryEntry::new(
-            &SettingId::new(HomogeneousMixing, 0),
+            SettingId::new(&HomogeneousMixing, 0),
             1.0,
         )];
         context.add_itinerary(person_id, itinerary)
@@ -471,14 +472,14 @@ mod test {
             let person_censustract = context.add_person(()).unwrap();
             let person_workplace = context.add_person(()).unwrap();
             let itinerary_all = vec![
-                ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
-                ItineraryEntry::new(&SettingId::new(CensusTract, 0), 1.0),
-                ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0),
+                ItineraryEntry::new(SettingId::new(&Home, 0), 1.0),
+                ItineraryEntry::new(SettingId::new(&CensusTract, 0), 1.0),
+                ItineraryEntry::new(SettingId::new(&Workplace, 0), 1.0),
             ];
-            let itinerary_home = vec![ItineraryEntry::new(&SettingId::new(Home, 0), 1.0)];
+            let itinerary_home = vec![ItineraryEntry::new(SettingId::new(&Home, 0), 1.0)];
             let itinerary_censustract =
-                vec![ItineraryEntry::new(&SettingId::new(CensusTract, 0), 1.0)];
-            let itinerary_workplace = vec![ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0)];
+                vec![ItineraryEntry::new(SettingId::new(&CensusTract, 0), 1.0)];
+            let itinerary_workplace = vec![ItineraryEntry::new(SettingId::new(&Workplace, 0), 1.0)];
             context
                 .add_itinerary(infectious_person, itinerary_all)
                 .unwrap();

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -8,7 +8,7 @@ use statrs::distribution::Exp;
 use crate::{
     population_loader::Alive,
     rate_fns::{InfectiousnessRateExt, InfectiousnessRateFn, RateFnId, ScaledRateFn},
-    settings::{ContextSettingExt, SettingType},
+    settings::{ContextSettingExt, SettingId, SettingType},
 };
 
 #[derive(Serialize, PartialEq, Debug, Clone, Copy)]
@@ -74,11 +74,10 @@ define_rng!(ForecastRng);
 pub fn infection_attempt(
     context: &Context,
     person_id: PersonId,
-    setting_type: &dyn SettingType,
-    setting_id: usize,
+    setting_id: SettingId<Box<dyn SettingType>>,
 ) -> Option<PersonId> {
     let next_contact = context
-        .get_contact(person_id, setting_type, setting_id, (Alive, true))
+        .get_contact(person_id, setting_id, (Alive, true))
         .unwrap()?;
     match context.get_person_property(next_contact, InfectionStatus) {
         InfectionStatusValue::Susceptible => Some(next_contact),
@@ -256,7 +255,7 @@ mod test {
         person_id: PersonId,
     ) -> Result<(), IxaError> {
         let itinerary = vec![ItineraryEntry::new(
-            &SettingId::new(HomogeneousMixing, 0),
+            SettingId::new(&HomogeneousMixing, 0),
             1.0,
         )];
         context.add_itinerary(person_id, itinerary)

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -71,10 +71,10 @@ pub fn max_total_infectiousness_multiplier(context: &Context, person_id: PersonI
 define_rng!(ForecastRng);
 
 // Infection attempt function for a context and given `PersonId`
-pub fn infection_attempt(
+pub fn infection_attempt<T: SettingType + ?Sized>(
     context: &Context,
     person_id: PersonId,
-    setting_id: SettingId<Box<dyn SettingType>>,
+    setting_id: SettingId<T>,
 ) -> Option<PersonId> {
     let next_contact = context
         .get_contact(person_id, setting_id, (Alive, true))

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -185,7 +185,7 @@ mod test {
             assert_eq!(
                 1,
                 context
-                    .get_setting_members::<Home>(SettingId::new(Home, home_id[i]))
+                    .get_setting_members(SettingId::new(&Home, home_id[i]))
                     .unwrap()
                     .len()
             );
@@ -193,7 +193,7 @@ mod test {
         assert_eq!(
             2,
             context
-                .get_setting_members::<CensusTract>(SettingId::new(CensusTract, census_tract_id))
+                .get_setting_members(SettingId::new(&CensusTract, census_tract_id))
                 .unwrap()
                 .len()
         );
@@ -229,14 +229,14 @@ mod test {
             assert_eq!(
                 1,
                 context
-                    .get_setting_members::<School>(SettingId::new(School, school_id[i]))
+                    .get_setting_members(SettingId::new(&School, school_id[i]))
                     .unwrap()
                     .len()
             );
             assert_eq!(
                 1,
                 context
-                    .get_setting_members::<Home>(SettingId::new(Home, home_id[i]))
+                    .get_setting_members(SettingId::new(&Home, home_id[i]))
                     .unwrap()
                     .len()
             );
@@ -244,7 +244,7 @@ mod test {
         assert_eq!(
             2,
             context
-                .get_setting_members::<CensusTract>(SettingId::new(CensusTract, census_tract_id))
+                .get_setting_members(SettingId::new(&CensusTract, census_tract_id))
                 .unwrap()
                 .len()
         );
@@ -270,14 +270,14 @@ mod test {
             assert_eq!(
                 1,
                 context
-                    .get_setting_members::<Workplace>(SettingId::new(Workplace, workplace_id[i]))
+                    .get_setting_members(SettingId::new(&Workplace, workplace_id[i]))
                     .unwrap()
                     .len()
             );
             assert_eq!(
                 1,
                 context
-                    .get_setting_members::<Home>(SettingId::new(Home, home_id[i]))
+                    .get_setting_members(SettingId::new(&Home, home_id[i]))
                     .unwrap()
                     .len()
             );
@@ -285,7 +285,7 @@ mod test {
         assert_eq!(
             2,
             context
-                .get_setting_members::<CensusTract>(SettingId::new(CensusTract, census_tract_id))
+                .get_setting_members(SettingId::new(&CensusTract, census_tract_id))
                 .unwrap()
                 .len()
         );

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -778,7 +778,7 @@ mod test {
             ItineraryEntry::new(SettingId::new(&Home, 1), 0.5),
             ItineraryEntry::new(SettingId::new(&Home, 2), 0.5),
         ];
-        let _ = context.add_itinerary(person, itinerary);
+        context.add_itinerary(person, itinerary).unwrap();
         let members = context
             .get_setting_members(SettingId::new(&Home, 2))
             .unwrap();
@@ -786,7 +786,7 @@ mod test {
 
         let person2 = context.add_person(()).unwrap();
         let itinerary2 = vec![ItineraryEntry::new(SettingId::new(&Home, 2), 1.0)];
-        let _ = context.add_itinerary(person2, itinerary2);
+        context.add_itinerary(person2, itinerary2).unwrap();
 
         let members2 = context
             .get_setting_members(SettingId::new(&Home, 2))
@@ -799,7 +799,7 @@ mod test {
         assert_eq!(members2.len(), 2);
 
         let itinerary3 = vec![ItineraryEntry::new(SettingId::new(&Home, 3), 0.5)];
-        let _ = context.add_itinerary(person, itinerary3);
+        context.add_itinerary(person, itinerary3).unwrap();
         let members2_removed = context
             .get_setting_members(SettingId::new(&Home, 2))
             .unwrap();
@@ -843,7 +843,7 @@ mod test {
                     ItineraryEntry::new(SettingId::new(&Home, s), 0.5),
                     ItineraryEntry::new(SettingId::new(&CensusTract, s), 0.5),
                 ];
-                let _ = context.add_itinerary(person, itinerary);
+                context.add_itinerary(person, itinerary).unwrap();
             }
             let members = context
                 .get_setting_members(SettingId::new(&Home, s))
@@ -874,14 +874,14 @@ mod test {
             for _ in 0..5 {
                 let person = context.add_person(()).unwrap();
                 let itinerary = vec![ItineraryEntry::new(SettingId::new(&Home, s), 0.5)];
-                let _ = context.add_itinerary(person, itinerary);
+                context.add_itinerary(person, itinerary).unwrap();
             }
         }
 
         let home_id = 0;
         let person = context.add_person(()).unwrap();
         let itinerary = vec![ItineraryEntry::new(SettingId::new(&Home, home_id), 0.5)];
-        let _ = context.add_itinerary(person, itinerary);
+        context.add_itinerary(person, itinerary).unwrap();
         let members = context
             .get_setting_members(SettingId::new(&Home, home_id))
             .unwrap();
@@ -930,13 +930,13 @@ mod test {
                     ItineraryEntry::new(SettingId::new(&Home, s), 0.5),
                     ItineraryEntry::new(SettingId::new(&CensusTract, s), 0.5),
                 ];
-                let _ = context.add_itinerary(person, itinerary);
+                context.add_itinerary(person, itinerary).unwrap();
             }
         }
         // Create a new person and register to home 0
         let itinerary = vec![ItineraryEntry::new(SettingId::new(&Home, 0), 1.0)];
         let person = context.add_person(()).unwrap();
-        let _ = context.add_itinerary(person, itinerary);
+        context.add_itinerary(person, itinerary).unwrap();
 
         // If only registered at home, total infectiousness multiplier should be (6 - 1) ^ (alpha)
         let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person);
@@ -950,7 +950,7 @@ mod test {
             ItineraryEntry::new(SettingId::new(&Home, 0), 0.5),
             ItineraryEntry::new(SettingId::new(&CensusTract, 0), 0.5),
         ];
-        let _ = context.add_itinerary(person, itinerary_complete);
+        context.add_itinerary(person, itinerary_complete).unwrap();
         let members_home = context
             .get_setting_members(SettingId::new(&Home, 0))
             .unwrap();
@@ -1006,8 +1006,8 @@ mod test {
                 ItineraryEntry::new(SettingId::new(&CensusTract, 0), 0.5),
             ];
             let itinerary_b = vec![ItineraryEntry::new(SettingId::new(&Home, 0), 1.0)];
-            let _ = context.add_itinerary(person_a, itinerary_a);
-            let _ = context.add_itinerary(person_b, itinerary_b);
+            context.add_itinerary(person_a, itinerary_a).unwrap();
+            context.add_itinerary(person_b, itinerary_b).unwrap();
 
             let setting_id = context.get_setting_for_contact(person_a).unwrap();
             assert_eq!(setting_id.setting_type.get_type_id(), TypeId::of::<Home>());
@@ -1059,8 +1059,8 @@ mod test {
             ItineraryEntry::new(SettingId::new(&CensusTract, 0), 0.5),
         ];
         let itinerary_b = vec![ItineraryEntry::new(SettingId::new(&Home, 0), 1.0)];
-        let _ = context.add_itinerary(person_a, itinerary_a);
-        let _ = context.add_itinerary(person_b, itinerary_b);
+        context.add_itinerary(person_a, itinerary_a).unwrap();
+        context.add_itinerary(person_b, itinerary_b).unwrap();
         let setting_id = context.get_setting_for_contact(person_a).unwrap();
         assert_eq!(
             Some(person_b),
@@ -1082,7 +1082,7 @@ mod test {
 
         let person_c = context.add_person(()).unwrap();
         let itinerary_c = vec![ItineraryEntry::new(SettingId::new(&CensusTract, 0), 0.5)];
-        let _ = context.add_itinerary(person_c, itinerary_c);
+        context.add_itinerary(person_c, itinerary_c).unwrap();
 
         let temp_census_tract = context
             .get_data_container(SettingDataPlugin)
@@ -1157,13 +1157,13 @@ mod test {
             for _ in 0..3 {
                 let person = context.add_person(()).unwrap();
                 let itinerary = vec![ItineraryEntry::new(SettingId::new(&Home, 0), 1.0)];
-                let _ = context.add_itinerary(person, itinerary);
+                context.add_itinerary(person, itinerary).unwrap();
             }
 
             for _ in 0..3 {
                 let person = context.add_person(()).unwrap();
                 let itinerary = vec![ItineraryEntry::new(SettingId::new(&CensusTract, 0), 1.0)];
-                let _ = context.add_itinerary(person, itinerary);
+                context.add_itinerary(person, itinerary).unwrap();
             }
 
             let person = context.add_person(()).unwrap();
@@ -1184,11 +1184,13 @@ mod test {
                 .unwrap()
                 .clone();
 
-            let _ = context.add_itinerary(person, itinerary_home);
+            context.add_itinerary(person, itinerary_home).unwrap();
             let contact_id_home = context.draw_contact_from_transmitter_itinerary(person, ());
             assert!(home_members.contains(&contact_id_home.unwrap().unwrap()));
 
-            let _ = context.add_itinerary(person, itinerary_censustract);
+            context
+                .add_itinerary(person, itinerary_censustract)
+                .unwrap();
             let contact_id_tract = context.draw_contact_from_transmitter_itinerary(person, ());
             assert!(tract_members.contains(&contact_id_tract.unwrap().unwrap()));
         }
@@ -1234,13 +1236,13 @@ mod test {
         for i in 0..3 {
             let person = context.add_person((Age, 42 + i)).unwrap();
             let itinerary = vec![ItineraryEntry::new(SettingId::new(&Home, 0), 1.0)];
-            let _ = context.add_itinerary(person, itinerary);
+            context.add_itinerary(person, itinerary).unwrap();
         }
 
         for i in 3..6 {
             let person = context.add_person((Age, 39 + i)).unwrap();
             let itinerary = vec![ItineraryEntry::new(SettingId::new(&CensusTract, 0), 1.0)];
-            let _ = context.add_itinerary(person, itinerary);
+            context.add_itinerary(person, itinerary).unwrap();
         }
 
         let person = context.add_person((Age, 42)).unwrap();
@@ -1261,7 +1263,7 @@ mod test {
             .unwrap()
             .clone();
 
-        let _ = context.add_itinerary(person, itinerary_home);
+        context.add_itinerary(person, itinerary_home).unwrap();
         let contact_id_home = context
             .draw_contact_from_transmitter_itinerary(person, (Age, 42))
             .unwrap();
@@ -1271,7 +1273,9 @@ mod test {
             42
         );
 
-        let _ = context.add_itinerary(person, itinerary_censustract);
+        context
+            .add_itinerary(person, itinerary_censustract)
+            .unwrap();
         let contact_id_tract = context
             .draw_contact_from_transmitter_itinerary(person, (Age, 42))
             .unwrap();


### PR DESCRIPTION
Don't fully love that we have to take a reference to a setting when making a new setting id, but this gets the job done of removing the tuple of specifying both `&dyn SettingType` and `id: usize` separately when needing the setting id.