### PR TITLE
Enable modular specification of aggregator functions. Fixes #143 and closes #145.

### DIFF
--- a/src/interventions/transmission_modifier_manager.rs
+++ b/src/interventions/transmission_modifier_manager.rs
@@ -542,23 +542,8 @@ mod test {
 
         context.infect_person(person_id, None);
 
-        let transmission_modifier_plugin = context
-            .get_data_container(TransmissionModifierPlugin)
-            .unwrap();
-
-        let transmission_modifier_map = transmission_modifier_plugin
-            .transmission_modifier_map
-            .get(&InfectionStatusValue::Infectious)
-            .unwrap();
-
-        let mut registered_modifiers = Vec::new();
-        for (t, f) in transmission_modifier_map {
-            registered_modifiers.push((*t, f(&context, person_id)));
-        }
-
         assert_almost_eq!(
-            transmission_modifier_plugin
-                .run_aggregator(InfectionStatusValue::Infectious, &registered_modifiers),
+            context.get_modified_relative_total_transmission_person(person_id),
             INFECTIOUS_PARTIAL * INFECTIOUS_PARTIAL,
             0.0
         );
@@ -588,23 +573,8 @@ mod test {
 
         context.infect_person(person_id, None);
 
-        let transmission_modifier_plugin = context
-            .get_data_container(TransmissionModifierPlugin)
-            .unwrap();
-
-        let transmission_modifier_map = transmission_modifier_plugin
-            .transmission_modifier_map
-            .get(&InfectionStatusValue::Infectious)
-            .unwrap();
-
-        let mut registered_modifiers = Vec::new();
-        for (t, f) in transmission_modifier_map {
-            registered_modifiers.push((*t, f(&context, person_id)));
-        }
-
         assert_almost_eq!(
-            transmission_modifier_plugin
-                .run_aggregator(InfectionStatusValue::Infectious, &registered_modifiers),
+            context.get_modified_relative_total_transmission_person(person_id),
             INFECTIOUS_PARTIAL + INFECTIOUS_PARTIAL,
             0.0
         );

--- a/src/interventions/transmission_modifier_manager.rs
+++ b/src/interventions/transmission_modifier_manager.rs
@@ -45,7 +45,7 @@ pub trait ContextTransmissionModifierExt {
     /// Register a generic transmission modifier function for a specific infection status.
     /// Float values returned from the modifier function indicate the relative infectiousness or
     /// susceptibility of the person with respect to the base value of 1.0.
-    fn register_transmission_modifier_fn<T: TransmissionModifier + 'static + std::fmt::Debug, F>(
+    fn register_transmission_modifier_fn<T: TransmissionModifier, F>(
         &mut self,
         infection_status: InfectionStatusValue,
         transmission_modifier_name: T,


### PR DESCRIPTION
This PR proposes a way to improve registering a custom aggregator function for transmission modifiers. In particular, the challenge with the old API (#120) was that in order to specify a custom aggregator function (i.e., a function that describes how to turn the modifier values from each transmission intervention into one overall float that is the person's total reduction in infectiousness/susceptibility), the user had to specify a function that depended on all _all_ transmission modifiers. This structure is not very modular.

Instead, this PR proposes an API that lets the user specify aggregator functions that depend on only a subset of transmission modifiers. Users get the value for a particular transmission modifier through the new `evaluate_transmission_modifier` method and combine modifiers in an arbitrary way, returning a float. For all modifiers not included through custom aggregation, the default aggregator (simple multiplication of modifiers) is used. In making these changes, I also had to implement a solution that addresses #145 by introducing a new trait that marks transmission modifiers -- `pub trait TransmissionModifier`.

In the future, we might add yet another degree of generality by allowing the user to override multiplication of modifiers as being the default aggregator in a simple one-line fashion, if there is a use-case for this.

Disclaimer: What I have done here is just a proposal. I encourage anyone interested to noodle around and play with the features they would desire in the API. I am sure this is also not the only way to fix the issues raised in #143 and #145.