### PR TITLE
Itinerary modifiers closes #118

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -389,3 +389,4 @@ Cargo.lock
 
 # Emacs
 *~
+*.org

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -224,6 +224,11 @@ pub trait ContextSettingExt {
         person_id: PersonId,
         itinerary: Vec<ItineraryEntry>,
     ) -> Result<(), IxaError>;
+    fn limit_itinerary_by_setting_types<T: SettingType + 'static>(
+        &mut self,
+        person_id: PersonId,
+        _setting_type: T,
+    ) -> Result<(), IxaError>;
     fn remove_modified_itinerary(
         &mut self,
         person_id: PersonId,
@@ -357,6 +362,33 @@ impl ContextSettingExt for Context {
             .setting_properties
             .insert(TypeId::of::<T>(), setting_props);
         Ok(())
+    }
+
+    // TODO: Limit itinerary to a vector of setting types instead of one setting type
+    fn limit_itinerary_by_setting_types<T: SettingType + 'static>(
+        &mut self,
+        person_id: PersonId,
+        _setting_type: T,
+    ) -> Result<(), IxaError> {
+        let container = self.get_data_container_mut(SettingDataPlugin);
+        match container.itineraries.get(&person_id) {
+            None => Err(IxaError::from("Can't find itinerary for person")),
+            Some(itineraries) => {
+                let mut modified_itinerary = Vec::<ItineraryEntry>::new();
+                for entry in itineraries.iter() {
+                    if entry.setting_type == TypeId::of::<T>() {
+                        modified_itinerary.push(*entry);
+                    }
+                }
+                if modified_itinerary.is_empty() {
+                    return Err(IxaError::from("limit itinerary resulted in empty modified itinerary"));
+                }
+                println!("LIMIT ITINERARY: {:?}", modified_itinerary);
+                
+                self.add_modified_itinerary(person_id, modified_itinerary)?;
+                Ok(())                
+            }
+        }        
     }
 
     fn remove_modified_itinerary(
@@ -1105,12 +1137,9 @@ mod test {
         assert_eq!(h1_members.len(), 3);
         assert_eq!(w_members.len(), 4);
         assert_eq!(s_members.len(), 1);
-        println!("WORK MEMBERS (isolation): {:?}", w_members);
-
 
         let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
-        let expected_multiplier = (1.0) * (2_f64).powf(alpha_h);        
-        println!("MULTIPLIER (isolation): {:?} -- expected {:?}", inf_multiplier, expected_multiplier);
+        let expected_multiplier = (1.0) * (2_f64).powf(alpha_h);
         assert_almost_eq!(inf_multiplier, expected_multiplier, 0.0);
         
         // 3. Remove modified itinerary; get back to normal
@@ -1131,16 +1160,113 @@ mod test {
         assert_eq!(h1_members.len(), 3);
         assert_eq!(w_members.len(), 5);
         assert_eq!(s_members.len(), 2);
-        println!("WORK MEMBERS (post-isolation): {:?}", w_members);
         
         let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
         let expected_multiplier = (1.0/3.0) * (2_f64).powf(alpha_h) +
             (1.0/3.0) * (4_f64).powf(alpha_w) +
             (1.0/3.0) * (1_f64).powf(alpha_s);
-        println!("MULTIPLIER (post-isolation): {:?} -- expected {:?}", inf_multiplier, expected_multiplier);       
+        
         assert_almost_eq!(inf_multiplier, expected_multiplier, 0.0);
     }
 
+        #[test]
+    fn test_limited_itinerary_modifier() {
+        /* H(0) = [0, 1, 2]
+           W(0) = [0,3,4] - 
+          Person 0 isolates using limited itinerary by setting type. Hence, members of 
+         */
+        let mut context = Context::new();
+        context.init_random(42);
+
+        context
+            .register_setting_type(
+                Home,
+                SettingProperties {
+                    alpha: 0.1,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+        context
+            .register_setting_type(
+                Workplace,
+                SettingProperties {
+                    alpha: 0.3,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+
+        let person = context.add_person(()).unwrap();
+        let itinerary = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+            ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0),
+        ];
+        
+        let _isolation_itinerary = [
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+        ];
+        
+        let _ = context.add_itinerary(person, itinerary.clone());
+
+        for _ in 0..2 {
+            let itinerary_home = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+            ];
+
+            let p_id = context.add_person(()).unwrap();
+            let _ = context.add_itinerary(p_id, itinerary_home);                        
+        }
+        for _ in 0..2 {
+            let itinerary_work = vec![
+                ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0),
+            ];
+
+            let p_id = context.add_person(()).unwrap();
+            let _ = context.add_itinerary(p_id, itinerary_work);                        
+        }
+        // Check membership
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 3);        
+        assert_eq!(w_members.len(), 3);
+        println!("HOME MEMBERS (limit default): {:?}", h_members);
+        println!("WORK MEMBERS (limit default): {:?}", w_members);
+        
+        // Reduce itinerary to only Home
+        let _ = context.limit_itinerary_by_setting_types(person, Home);
+                // Check membership
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 3);        
+        assert_eq!(w_members.len(), 2);
+        println!("HOME MEMBERS (limit isolation): {:?}", h_members);
+        println!("WORK MEMBERS (limit isolation): {:?}", w_members);
+
+        let _ = context.remove_modified_itinerary(person);
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 3);        
+        assert_eq!(w_members.len(), 3);
+        
+        println!("HOME MEMBERS (limit isolation): {:?}", h_members);
+        println!("WORK MEMBERS (limit isolation): {:?}", w_members);       
+
+    }
+
+    
     #[test]
     fn test_setting_registration() {
         let mut context = Context::new();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -371,9 +371,9 @@ impl ContextSettingExt for Context {
         }
         let container = self.get_data_container_mut(SettingDataPlugin);
 
-        // Clean up settings that from previous itinerary, if there is one
-        if let Some(previous_itinerary) = container.modified_itineraries.get(&person_id) {
-            for itinerary_entry in previous_itinerary {
+        // If there's a modified itinerary present, replace with this 
+        if let Some(previous_mod_itinerary) = container.modified_itineraries.get(&person_id) {
+            for itinerary_entry in previous_mod_itinerary {
                 // Remove the person from the previous itinerary
                 container
                     .members
@@ -385,6 +385,22 @@ impl ContextSettingExt for Context {
             }
         }
 
+        // Remove people from default itinerary, if there's one
+        match container.itineraries.get(&person_id) {
+            None => return Err(IxaError::from("Can't modify itinerary if there isn't one present")),
+            Some(previous_itinerary) => {
+                for itinerary_entry in previous_itinerary {
+                    // Remove the person from the previous itinerary
+                    container
+                        .members
+                        .entry(itinerary_entry.setting_type)
+                        .or_default()
+                        .entry(itinerary_entry.setting_id)
+                        .or_default()
+                        .retain(|&x| x != person_id);
+                }
+            }
+        }
         for itinerary_entry in &itinerary {
             // TODO: If we are changing a person's itinerary, the person_id should be removed from vector
             // This isn't the same as the concept of being present or not.
@@ -850,14 +866,13 @@ mod test {
         assert_eq!(members1_removed.len(), 0);
     }
 
-        #[test]
-    fn test_itinerary_modifiers() {
+    #[test]
+    fn test_one_person_itinerary_modifier() {
         /*
         Create two itineraries: default (home, work, censustract), and modified (home)
-        Add one person to the simulation, modify its itinerary
+        Add one person to the simulation, modify its itinerary and check membership
          */
         let mut context = Context::new();
-        context.init_random(1234);
         context
             .register_setting_type(
                 Home,
@@ -901,19 +916,172 @@ mod test {
         let members = context
             .get_setting_members::<Home>(SettingId::new(Home, 0))
             .unwrap();
+        assert_eq!(members.len(), 1);
+        
+        let _ = context.add_modified_itinerary(person, isolation_itinerary);
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 1);
+        
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+
+        assert_eq!(w_members.len(), 0); 
+
+    }
+    
+    #[test]
+    fn test_itinerary_modifiers() {
+        /* For the settings:
+        H(0) = [0, 1, 2]
+        H(1) = [3, 4, 5]
+        W(0) = [0, 1, 2, 5]
+        SCH(0) = [0, 3, 4]
+        **Isolate person 0**
+         */
+        let mut context = Context::new();
+        context
+            .register_setting_type(
+                Home,
+                SettingProperties {
+                    alpha: 0.1,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+        context
+            .register_setting_type(
+                Workplace,
+                SettingProperties {
+                    alpha: 0.3,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+        context
+            .register_setting_type(
+                School,
+                SettingProperties {
+                    alpha: 0.01,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+        
+        let itinerary_map = HashMap::from([
+            (0, HashMap::from([
+                ("Home",0), ("Workplace", 0), ("School",0)
+            ])),
+            (1, HashMap::from([
+                ("Home",0), ("Workplace", 0)
+            ])),
+            (2, HashMap::from([
+                ("Home",0), ("Workplace", 0)
+            ])),
+            (3, HashMap::from([
+                ("Home",1), ("School", 0)
+            ])),
+            (4, HashMap::from([
+                ("Home",1), ("Workplace", 0)
+            ])),
+            (5, HashMap::from([
+                ("Home",1), ("Workplace", 0)
+            ])),                        
+        ]);
+
+        let mut person_0: Option<PersonId> = None;
+        for p_id in 0..itinerary_map.len() {
+            let p_map = itinerary_map.get(&p_id).unwrap();
+            let mut p_itinerary = Vec::<ItineraryEntry>::new();
+            for (s_type, s_id) in p_map.iter() {
+                match *s_type {
+                    "Home" => p_itinerary.push(ItineraryEntry::new(&SettingId::new(Home, *s_id), 1.0)),
+                    "School" => p_itinerary.push(ItineraryEntry::new(&SettingId::new(School, *s_id), 1.0)),
+                    "Workplace" => p_itinerary.push(ItineraryEntry::new(&SettingId::new(Workplace, *s_id), 1.0)),
+                    _ => println!("Setting type not found"),
+                    
+                }                
+            }
+            let person = context.add_person(()).unwrap();
+            let _e = context.add_itinerary(person, p_itinerary);
+            if p_id == 0 {
+                person_0 = Some(person);
+            }
+        }
+        // 1. Verify that initial members are right
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        let h1_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 1))
+            .unwrap();
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+        let s_members = context
+            .get_setting_members::<School>(SettingId::new(School, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 3);        
+        assert_eq!(h1_members.len(), 3);
+        assert_eq!(w_members.len(), 5);
+        assert_eq!(s_members.len(), 2);
+
+        // 2. Isolate person with itinerary [Home 0 , 1.0]
+        let isolation_itinerary = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+        ];        
+        let _ = context.add_modified_itinerary(person_0.unwrap(), isolation_itinerary);
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        let h1_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 1))
+            .unwrap();
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+        let s_members = context
+            .get_setting_members::<School>(SettingId::new(School, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 3);        
+        assert_eq!(h1_members.len(), 3);
+        assert_eq!(w_members.len(), 4);
+        assert_eq!(s_members.len(), 1);
+
+        /*
+        let person = context.add_person(()).unwrap();
+        let itinerary = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+            ItineraryEntry::new(&SettingId::new(CensusTract, 0), 1.0),
+            ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0),
+        ];
+        let isolation_itinerary = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+        ];
+        
+        let _ = context.add_itinerary(person, itinerary);
+        let members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
         println!("H MEMBERS: {:?}", members);
-        assert_eq!(members.len(), 1); 
-        let _ = context.add_itinerary(person, isolation_itinerary);
+        assert_eq!(members.len(), 1);
+        
+        let _ = context.add_modified_itinerary(person, isolation_itinerary);
         let h_members = context
             .get_setting_members::<Home>(SettingId::new(Home, 0))
             .unwrap();
         println!("H MEMBERS - isolation: {:?}", h_members);
-        assert_eq!(h_members.len(), 1);
+
         let w_members = context
             .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
             .unwrap();
         println!("WORK MEMBERS: {:?}", w_members);
-        assert_eq!(w_members.len(), 0); 
+
+        assert_eq!(h_members.len(), 1);
+        assert_eq!(w_members.len(), 0);
+*/
 
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -123,6 +123,7 @@ pub struct SettingDataContainer {
     // For each setting type, have a map of each setting id and a list of members
     members: HashMap<TypeId, HashMap<usize, Vec<PersonId>>>,
     itineraries: HashMap<PersonId, Vec<ItineraryEntry>>,
+    modified_itineraries: HashMap<PersonId, Vec<ItineraryEntry>>,
 }
 
 impl SettingDataContainer {
@@ -132,6 +133,7 @@ impl SettingDataContainer {
             setting_properties: HashMap::new(),
             members: HashMap::new(),
             itineraries: HashMap::new(),
+            modified_itineraries: HashMap::new(),
         }
     }
     fn get_setting_members(
@@ -141,11 +143,22 @@ impl SettingDataContainer {
     ) -> Option<&Vec<PersonId>> {
         self.members.get(setting_type)?.get(&setting_id)
     }
+    fn get_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>>{
+        if let Some(modified_itinerary) = self.modified_itineraries.get(&person_id) {
+            return Some(modified_itinerary);
+        }
+            
+        if let Some(itinerary) = self.itineraries.get(&person_id) {
+            return Some(itinerary);
+        }
+        None
+    }
     fn with_itinerary<F>(&self, person_id: PersonId, mut callback: F)
     where
         F: FnMut(&dyn SettingType, &SettingProperties, &Vec<PersonId>, f64),
     {
-        if let Some(itinerary) = self.itineraries.get(&person_id) {
+           
+        if let Some(itinerary) = self.get_itinerary(person_id) {
             for entry in itinerary {
                 let setting_type = self.setting_types.get(&entry.setting_type).unwrap();
                 let setting_props = self.setting_properties.get(&entry.setting_type).unwrap();
@@ -202,6 +215,11 @@ pub trait ContextSettingExt {
         setting_props: SettingProperties,
     ) -> Result<(), IxaError>;
     fn add_itinerary(
+        &mut self,
+        person_id: PersonId,
+        itinerary: Vec<ItineraryEntry>,
+    ) -> Result<(), IxaError>;
+    fn add_modified_itinerary(
         &mut self,
         person_id: PersonId,
         itinerary: Vec<ItineraryEntry>,
@@ -337,6 +355,63 @@ impl ContextSettingExt for Context {
         Ok(())
     }
 
+    fn add_modified_itinerary(
+        &mut self,
+        person_id: PersonId,
+        mut itinerary: Vec<ItineraryEntry>,
+    ) -> Result<(), IxaError> {
+        // Normalize itinerary ratios
+        self.validate_itinerary(&itinerary)?;
+
+        let total_ratio: f64 = itinerary.iter().map(|entry| entry.ratio).sum();
+        // If we passed validation, we know setting entries aren't all zero, so we can divide by
+        // total_ratio without worrying about dividing by zero.
+        for entry in &mut itinerary {
+            entry.ratio /= total_ratio;
+        }
+        let container = self.get_data_container_mut(SettingDataPlugin);
+
+        // Clean up settings that from previous itinerary, if there is one
+        if let Some(previous_itinerary) = container.modified_itineraries.get(&person_id) {
+            for itinerary_entry in previous_itinerary {
+                // Remove the person from the previous itinerary
+                container
+                    .members
+                    .entry(itinerary_entry.setting_type)
+                    .or_default()
+                    .entry(itinerary_entry.setting_id)
+                    .or_default()
+                    .retain(|&x| x != person_id);
+            }
+        }
+
+        for itinerary_entry in &itinerary {
+            // TODO: If we are changing a person's itinerary, the person_id should be removed from vector
+            // This isn't the same as the concept of being present or not.
+            if !container
+                .setting_types
+                .contains_key(&itinerary_entry.setting_type)
+            {
+                return Err(IxaError::from(
+                    "Itinerary entry setting type not registered",
+                ));
+            }
+             
+            // TODO: MAYBE CHANGE THIS TO AN INDEX SET
+            container
+                .members
+                .entry(itinerary_entry.setting_type)
+                .or_default()
+                .entry(itinerary_entry.setting_id)
+                .or_default()
+                .push(person_id);
+        }
+        container.modified_itineraries.insert(person_id, itinerary);
+        
+        Ok(())
+    }
+
+    
     fn add_itinerary(
         &mut self,
         person_id: PersonId,
@@ -352,7 +427,20 @@ impl ContextSettingExt for Context {
             entry.ratio /= total_ratio;
         }
         let container = self.get_data_container_mut(SettingDataPlugin);
-        let mut current_setting_ids = vec![];
+
+        // Clean up settings that from previous itinerary, if there is one
+        if let Some(previous_itinerary) = container.itineraries.get(&person_id) {
+            for itinerary_entry in previous_itinerary {
+                // Remove the person from the previous itinerary
+                container
+                    .members
+                    .entry(itinerary_entry.setting_type)
+                    .or_default()
+                    .entry(itinerary_entry.setting_id)
+                    .or_default()
+                    .retain(|&x| x != person_id);
+            }
+        }
 
         for itinerary_entry in &itinerary {
             // TODO: If we are changing a person's itinerary, the person_id should be removed from vector
@@ -365,6 +453,8 @@ impl ContextSettingExt for Context {
                     "Itinerary entry setting type not registered",
                 ));
             }
+             
+            // TODO: MAYBE CHANGE THIS TO AN INDEX SET
             container
                 .members
                 .entry(itinerary_entry.setting_type)
@@ -372,28 +462,9 @@ impl ContextSettingExt for Context {
                 .entry(itinerary_entry.setting_id)
                 .or_default()
                 .push(person_id);
-            current_setting_ids.push((itinerary_entry.setting_type, itinerary_entry.setting_id));
         }
-
-        // Clean up settings that the person is no longer a member of
-        if let Some(previous_itinerary) = container.itineraries.insert(person_id, itinerary) {
-            // Remove the person from the previous itinerary entries not modified already
-            for itinerary_entry in previous_itinerary {
-                //Check if the entry of setting ID and type is not in the current itinerary
-                if !current_setting_ids
-                    .contains(&(itinerary_entry.setting_type, itinerary_entry.setting_id))
-                {
-                    // Remove the person from the previous itinerary
-                    container
-                        .members
-                        .entry(itinerary_entry.setting_type)
-                        .or_default()
-                        .entry(itinerary_entry.setting_id)
-                        .or_default()
-                        .retain(|&x| x != person_id);
-                }
-            }
-        }
+        container.itineraries.insert(person_id, itinerary);
+        
         Ok(())
     }
 
@@ -444,8 +515,7 @@ impl ContextSettingExt for Context {
     fn get_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
         self.get_data_container(SettingDataPlugin)
             .expect("Person should be added to settings")
-            .itineraries
-            .get(&person_id)
+            .get_itinerary(person_id)
     }
 
     fn get_contact<T: SettingType + 'static, Q: Query + 'static>(
@@ -526,7 +596,7 @@ mod test {
         parameters::{GlobalParams, ItinerarySpecificationType, RateFnType},
         settings::ContextSettingExt,
     };
-    use ixa::{define_person_property, ContextGlobalPropertiesExt, ContextPeopleExt};
+    use ixa::{context, define_person_property, ContextGlobalPropertiesExt, ContextPeopleExt};
     use statrs::assert_almost_eq;
 
     #[test]
@@ -778,6 +848,73 @@ mod test {
             .get_setting_members::<Home>(SettingId::new(Home, 1))
             .unwrap();
         assert_eq!(members1_removed.len(), 0);
+    }
+
+        #[test]
+    fn test_itinerary_modifiers() {
+        /*
+        Create two itineraries: default (home, work, censustract), and modified (home)
+        Add one person to the simulation, modify its itinerary
+         */
+        let mut context = Context::new();
+        context.init_random(1234);
+        context
+            .register_setting_type(
+                Home,
+                SettingProperties {
+                    alpha: 0.1,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+        context
+            .register_setting_type(
+                Workplace,
+                SettingProperties {
+                    alpha: 0.3,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+        context
+            .register_setting_type(
+                CensusTract,
+                SettingProperties {
+                    alpha: 0.01,
+                    itinerary_specification: None,
+                },
+            )
+            .unwrap();
+
+
+        let person = context.add_person(()).unwrap();
+        let itinerary = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+            ItineraryEntry::new(&SettingId::new(CensusTract, 0), 1.0),
+            ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0),
+        ];
+        let isolation_itinerary = vec![
+            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
+        ];
+        
+        let _ = context.add_itinerary(person, itinerary);
+        let members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        println!("H MEMBERS: {:?}", members);
+        assert_eq!(members.len(), 1); 
+        let _ = context.add_itinerary(person, isolation_itinerary);
+        let h_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 0))
+            .unwrap();
+        println!("H MEMBERS - isolation: {:?}", h_members);
+        assert_eq!(h_members.len(), 1);
+        let w_members = context
+            .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
+            .unwrap();
+        println!("WORK MEMBERS: {:?}", w_members);
+        assert_eq!(w_members.len(), 0); 
+
     }
 
     #[test]
@@ -1354,9 +1491,12 @@ mod test {
         let total_ratio: Vec<f64> = itinerary.iter().map(|entry| entry.ratio).collect();
         assert_eq!(total_ratio, vec![0.5, 0.25, 0.25]);
     }
+
+
+    
     /*TODO:
     Test failure of getting properties if not initialized
     Test failure if a setting is registered more than once?
     Test that proportions either add to 1 or that they are weighted based on proportion
-    */
+     */
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -224,6 +224,10 @@ pub trait ContextSettingExt {
         person_id: PersonId,
         itinerary: Vec<ItineraryEntry>,
     ) -> Result<(), IxaError>;
+    fn remove_modified_itinerary(
+        &mut self,
+        person_id: PersonId,
+    ) -> Result<(), IxaError>;
     fn validate_itinerary(&self, itinerary: &[ItineraryEntry]) -> Result<(), IxaError>;
     fn get_setting_members<T: SettingType + 'static>(
         &self,
@@ -355,6 +359,51 @@ impl ContextSettingExt for Context {
         Ok(())
     }
 
+    fn remove_modified_itinerary(
+        &mut self,
+        person_id: PersonId,
+    ) -> Result<(), IxaError> {
+        let container = self.get_data_container_mut(SettingDataPlugin);
+
+        // If there's a modified itinerary present, remove
+        if let Some(previous_mod_itinerary) = container.modified_itineraries.get(&person_id) {
+            for itinerary_entry in previous_mod_itinerary {
+                container
+                    .members
+                    .entry(itinerary_entry.setting_type)
+                    .or_default()
+                    .entry(itinerary_entry.setting_id)
+                    .or_default()
+                    .retain(|&x| x != person_id);
+            }
+        }
+
+        // Get people back to default itinerary, if there's one
+        match container.itineraries.get(&person_id) {
+            None => return Err(IxaError::from("Can't modify itinerary if there isn't one present")),
+            Some(default_itinerary) => {
+                for itinerary_entry in default_itinerary {
+                    if !container
+                        .setting_types
+                        .contains_key(&itinerary_entry.setting_type) {
+                            return Err(IxaError::from(
+                                "Itinerary entry setting type not registered",
+                            ));
+                        }
+             
+                    container
+                        .members
+                        .entry(itinerary_entry.setting_type)
+                        .or_default()
+                        .entry(itinerary_entry.setting_id)
+                        .or_default()
+                        .push(person_id);
+                }
+            }
+        }        
+        Ok(())
+    }
+    
     fn add_modified_itinerary(
         &mut self,
         person_id: PersonId,
@@ -934,13 +983,6 @@ mod test {
     
     #[test]
     fn test_itinerary_modifiers() {
-        /* For the settings:
-        H(0) = [0, 1, 2]
-        H(1) = [3, 4, 5]
-        W(0) = [0, 1, 2, 5]
-        SCH(0) = [0, 3, 4]
-        **Isolate person 0**
-         */
         let mut context = Context::new();
         context
             .register_setting_type(
@@ -1027,7 +1069,8 @@ mod test {
         assert_eq!(h1_members.len(), 3);
         assert_eq!(w_members.len(), 5);
         assert_eq!(s_members.len(), 2);
-
+        println!("WORK MEMBERS (default): {:?}", w_members);
+        
         // 2. Isolate person with itinerary [Home 0 , 1.0]
         let isolation_itinerary = vec![
             ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
@@ -1049,40 +1092,27 @@ mod test {
         assert_eq!(h1_members.len(), 3);
         assert_eq!(w_members.len(), 4);
         assert_eq!(s_members.len(), 1);
-
-        /*
-        let person = context.add_person(()).unwrap();
-        let itinerary = vec![
-            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
-            ItineraryEntry::new(&SettingId::new(CensusTract, 0), 1.0),
-            ItineraryEntry::new(&SettingId::new(Workplace, 0), 1.0),
-        ];
-        let isolation_itinerary = vec![
-            ItineraryEntry::new(&SettingId::new(Home, 0), 1.0),
-        ];
+        println!("WORK MEMBERS (isolation): {:?}", w_members);
         
-        let _ = context.add_itinerary(person, itinerary);
-        let members = context
-            .get_setting_members::<Home>(SettingId::new(Home, 0))
-            .unwrap();
-        println!("H MEMBERS: {:?}", members);
-        assert_eq!(members.len(), 1);
-        
-        let _ = context.add_modified_itinerary(person, isolation_itinerary);
+        // 3. Remove modified itinerary; get back to normal
+        let _ = context.remove_modified_itinerary(person_0.unwrap());
         let h_members = context
             .get_setting_members::<Home>(SettingId::new(Home, 0))
             .unwrap();
-        println!("H MEMBERS - isolation: {:?}", h_members);
-
+        let h1_members = context
+            .get_setting_members::<Home>(SettingId::new(Home, 1))
+            .unwrap();
         let w_members = context
             .get_setting_members::<Workplace>(SettingId::new(Workplace, 0))
             .unwrap();
-        println!("WORK MEMBERS: {:?}", w_members);
-
-        assert_eq!(h_members.len(), 1);
-        assert_eq!(w_members.len(), 0);
-*/
-
+        let s_members = context
+            .get_setting_members::<School>(SettingId::new(School, 0))
+            .unwrap();
+        assert_eq!(h_members.len(), 3);        
+        assert_eq!(h1_members.len(), 3);
+        assert_eq!(w_members.len(), 5);
+        assert_eq!(s_members.len(), 2);
+        println!("WORK MEMBERS (post-isolation): {:?}", w_members);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -378,6 +378,8 @@ impl ContextSettingExt for Context {
             }
         }
 
+        container.modified_itineraries.remove(&person_id);
+        
         // Get people back to default itinerary, if there's one
         match container.itineraries.get(&person_id) {
             None => return Err(IxaError::from("Can't modify itinerary if there isn't one present")),
@@ -1052,6 +1054,10 @@ mod test {
                 person_0 = Some(person);
             }
         }
+        let alpha_h = context.get_setting_properties(Home).unwrap().alpha;
+        let alpha_w = context.get_setting_properties(Workplace).unwrap().alpha;
+        let alpha_s = context.get_setting_properties(School).unwrap().alpha;
+        
         // 1. Verify that initial members are right
         let h_members = context
             .get_setting_members::<Home>(SettingId::new(Home, 0))
@@ -1070,6 +1076,13 @@ mod test {
         assert_eq!(w_members.len(), 5);
         assert_eq!(s_members.len(), 2);
         println!("WORK MEMBERS (default): {:?}", w_members);
+
+        let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
+        let expected_multiplier = (1.0/3.0) * (2_f64).powf(alpha_h) +
+            (1.0/3.0) * (4_f64).powf(alpha_w) +
+            (1.0/3.0) * (1_f64).powf(alpha_s);
+        println!("MULTIPLIER (pre-isolation): {:?} -- expected {:?}", inf_multiplier, expected_multiplier);       
+        assert_almost_eq!(inf_multiplier, expected_multiplier, 0.0);
         
         // 2. Isolate person with itinerary [Home 0 , 1.0]
         let isolation_itinerary = vec![
@@ -1093,6 +1106,12 @@ mod test {
         assert_eq!(w_members.len(), 4);
         assert_eq!(s_members.len(), 1);
         println!("WORK MEMBERS (isolation): {:?}", w_members);
+
+
+        let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
+        let expected_multiplier = (1.0) * (2_f64).powf(alpha_h);        
+        println!("MULTIPLIER (isolation): {:?} -- expected {:?}", inf_multiplier, expected_multiplier);
+        assert_almost_eq!(inf_multiplier, expected_multiplier, 0.0);
         
         // 3. Remove modified itinerary; get back to normal
         let _ = context.remove_modified_itinerary(person_0.unwrap());
@@ -1113,6 +1132,13 @@ mod test {
         assert_eq!(w_members.len(), 5);
         assert_eq!(s_members.len(), 2);
         println!("WORK MEMBERS (post-isolation): {:?}", w_members);
+        
+        let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
+        let expected_multiplier = (1.0/3.0) * (2_f64).powf(alpha_h) +
+            (1.0/3.0) * (4_f64).powf(alpha_w) +
+            (1.0/3.0) * (1_f64).powf(alpha_s);
+        println!("MULTIPLIER (post-isolation): {:?} -- expected {:?}", inf_multiplier, expected_multiplier);       
+        assert_almost_eq!(inf_multiplier, expected_multiplier, 0.0);
     }
 
     #[test]
@@ -1137,7 +1163,6 @@ mod test {
             )
             .unwrap();
         for s in 0..5 {
-            // Create 5 people
             for _ in 0..5 {
                 let person = context.add_person(()).unwrap();
                 let itinerary = vec![
@@ -1152,7 +1177,7 @@ mod test {
             let tract_members = context
                 .get_setting_members::<CensusTract>(SettingId::new(CensusTract, s))
                 .unwrap();
-            // Get the number of people for these settings and should be 5
+            
             assert_eq!(members.len(), 5);
             assert_eq!(tract_members.len(), 5);
         }


### PR DESCRIPTION
This is a first attempt to add itinerary modifiers. It introduces a new hashmap of `modified_itineraries` which if present would be used as the itinerary for a person. 

Issues:
- Adding and modifying itineraries implies removing and adding people to a vector. This can be intensive.   
- Right now, ratios are not redistributed among other settings, that is up to the user when defining a modified itinerary. 