### PR TITLE
hotfix: make option enum properties that require debug instead have a none variant

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -307,12 +307,13 @@ mod test {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
     pub enum InfectiousnessProportion {
+        None,
         Partial,
     }
     define_person_property_with_default!(
         InfectiousnessProportionStatus,
-        Option<InfectiousnessProportion>,
-        None
+        InfectiousnessProportion,
+        InfectiousnessProportion::None
     );
 
     pub const INFECTIOUS_PARTIAL: f64 = 0.7;
@@ -353,7 +354,7 @@ mod test {
                 .store_transmission_modifier_values(
                     InfectionStatusValue::Infectious,
                     InfectiousnessProportionStatus,
-                    &[(Some(InfectiousnessProportion::Partial), INFECTIOUS_PARTIAL)],
+                    &[(InfectiousnessProportion::Partial, INFECTIOUS_PARTIAL)],
                 )
                 .unwrap();
 
@@ -370,7 +371,7 @@ mod test {
             let infectious_person = context
                 .add_person((
                     InfectiousnessProportionStatus,
-                    Some(InfectiousnessProportion::Partial),
+                    InfectiousnessProportion::Partial,
                 ))
                 .unwrap();
             set_homogeneous_mixing_itinerary(&mut context, infectious_person).unwrap();

--- a/src/interventions/transmission_modifier_manager.rs
+++ b/src/interventions/transmission_modifier_manager.rs
@@ -214,12 +214,13 @@ mod test {
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
     pub enum InfectiousnessProportion {
+        None,
         Partial,
     }
     define_person_property_with_default!(
         InfectiousnessProportionStatus,
-        Option<InfectiousnessProportion>,
-        None
+        InfectiousnessProportion,
+        InfectiousnessProportion::None
     );
 
     pub const SUSCEPTIBLE_PARTIAL: f64 = 0.8;
@@ -274,7 +275,7 @@ mod test {
             .store_transmission_modifier_values(
                 InfectionStatusValue::Infectious,
                 InfectiousnessProportionStatus,
-                &[(Some(InfectiousnessProportion::Partial), INFECTIOUS_PARTIAL)],
+                &[(InfectiousnessProportion::Partial, INFECTIOUS_PARTIAL)],
             )
             .unwrap();
         context
@@ -554,7 +555,7 @@ mod test {
                 (MandatoryInterventionStatus, MandatoryIntervention::Partial),
                 (
                     InfectiousnessProportionStatus,
-                    Some(InfectiousnessProportion::Partial),
+                    InfectiousnessProportion::Partial,
                 ),
             ))
             .unwrap();
@@ -587,7 +588,7 @@ mod test {
         context.set_person_property(
             person_id,
             InfectiousnessProportionStatus,
-            Some(InfectiousnessProportion::Partial),
+            InfectiousnessProportion::Partial,
         );
         assert_almost_eq!(
             context.get_relative_total_transmission(person_id),
@@ -595,7 +596,11 @@ mod test {
             0.0
         );
 
-        context.set_person_property(person_id, InfectiousnessProportionStatus, None);
+        context.set_person_property(
+            person_id,
+            InfectiousnessProportionStatus,
+            InfectiousnessProportion::None,
+        );
         assert_almost_eq!(
             context.get_relative_total_transmission(person_id),
             INFECTIOUS_PARTIAL,


### PR DESCRIPTION
Fixes failing tests in #149 due to ixa update https://github.com/CDCgov/ixa/pull/377