### PR TITLE
Use `sample_people()` method

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -132,7 +132,10 @@ fn query_susceptibles_and_seed(
     proportion_to_seed: f64,
     seed_fn: impl Fn(&mut Context, PersonId),
 ) {
+    #[allow(clippy::cast_precision_loss)]
     let n = proportion_to_seed * context.get_current_population() as f64;
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let susceptibles = context.sample_people(
         InfectionRng,
         (InfectionStatus, InfectionStatusValue::Susceptible),


### PR DESCRIPTION
### Changes
* Updated the `ixa` dependency from version `0.1.1` to `0.2.0` in `Cargo.toml` to incorporate the latest features and fixes.
* Replaced the use of `context.query_people` with `context.sample_people`, which directly samples a subset of susceptibles based on the calculated number (`n`)
    - Previous implementation had the proportion being calculated on susceptibles remaining, meaning that seeding infections impacted the proportion of "recovered" in the population. Now `n` is strictly based on population size