### PR TITLE
Use PluginContext syntax for extensions

### DIFF
--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -1,6 +1,6 @@
 use ixa::{
     define_derived_property, define_person_property_with_default, define_rng, trace, Context,
-    ContextPeopleExt, ContextRandomExt, PersonId,
+    ContextPeopleExt, ContextRandomExt, PersonId, PluginContext,
 };
 use serde::Serialize;
 use statrs::distribution::Exp;
@@ -176,19 +176,7 @@ pub fn evaluate_forecast(
     true
 }
 
-pub trait InfectionContextExt {
-    fn infect_person(
-        &mut self,
-        target_id: PersonId,
-        source_id: Option<PersonId>,
-        setting_type: Option<&'static str>,
-        setting_id: Option<usize>,
-    );
-    fn recover_person(&mut self, person_id: PersonId);
-    fn get_elapsed_infection_time(&self, person_id: PersonId) -> f64;
-}
-
-impl InfectionContextExt for Context {
+pub trait InfectionContextExt: PluginContext + ContextPeopleExt {
     // This function should be called from the main loop whenever
     // someone is first infected. It assigns all their properties needed to
     // calculate intrinsic infectiousness
@@ -212,7 +200,6 @@ impl InfectionContextExt for Context {
             },
         );
     }
-
     fn recover_person(&mut self, person_id: PersonId) {
         let recovery_time = self.get_current_time();
         let InfectionDataValue::Infectious { infection_time, .. } =
@@ -229,7 +216,6 @@ impl InfectionContextExt for Context {
             },
         );
     }
-
     fn get_elapsed_infection_time(&self, person_id: PersonId) -> f64 {
         let InfectionDataValue::Infectious { infection_time, .. } =
             self.get_person_property(person_id, InfectionData)
@@ -239,6 +225,7 @@ impl InfectionContextExt for Context {
         self.get_current_time() - infection_time
     }
 }
+impl InfectionContextExt for Context {}
 
 #[cfg(test)]
 mod test {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Debug, path::PathBuf};
 
-use ixa::{define_global_property, ContextGlobalPropertiesExt, IxaError};
+use ixa::{define_global_property, Context, ContextGlobalPropertiesExt, IxaError, PluginContext};
 use serde::{Deserialize, Serialize};
 
 use crate::policies::{validate_guidance_policy, Policies};
@@ -233,16 +233,13 @@ fn validate_inputs(parameters: &Params) -> Result<(), IxaError> {
 
 define_global_property!(GlobalParams, Params, validate_inputs);
 
-pub trait ContextParametersExt {
-    fn get_params(&self) -> &Params;
-}
-
-impl ContextParametersExt for ixa::Context {
+pub trait ContextParametersExt: PluginContext + ContextGlobalPropertiesExt {
     fn get_params(&self) -> &Params {
         self.get_global_property_value(GlobalParams)
             .expect("Expected GlobalParams to be set")
     }
 }
+impl ContextParametersExt for Context {}
 
 #[cfg(test)]
 mod test {

--- a/src/policies/updated_guidance.rs
+++ b/src/policies/updated_guidance.rs
@@ -1,6 +1,7 @@
 use ixa::{
     define_derived_property, define_person_property_with_default, define_rng, trace, Context,
     ContextPeopleExt, ContextRandomExt, IxaError, PersonId, PersonPropertyChangeEvent,
+    PluginContext,
 };
 
 use crate::{
@@ -29,29 +30,9 @@ struct InterventionPolicyParameters {
     isolation_delay_period: f64,
 }
 
-trait ContextIsolationGuidanceInternalExt {
-    fn modify_isolation_status(
-        &mut self,
-        person: PersonId,
-        isolation_status: bool,
-    ) -> Result<(), IxaError>;
-    fn isolation(
-        &mut self,
-        person_id: PersonId,
-        intervention_policy_parameters: InterventionPolicyParameters,
-    );
-    fn post_isolation(
-        &mut self,
-        person_id: PersonId,
-        intervention_policy_parameters: InterventionPolicyParameters,
-    );
-    fn setup_isolation_guidance_event_sequence(
-        &mut self,
-        intervention_policy_parameters: InterventionPolicyParameters,
-    );
-}
-
-impl ContextIsolationGuidanceInternalExt for Context {
+trait ContextIsolationGuidanceInternalExt:
+    PluginContext + ContextRandomExt + ContextPeopleExt + ContextSettingExt
+{
     fn modify_isolation_status(
         &mut self,
         person: PersonId,
@@ -124,6 +105,7 @@ impl ContextIsolationGuidanceInternalExt for Context {
         );
     }
 }
+impl ContextIsolationGuidanceInternalExt for Context {}
 
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
     let &Params {

--- a/src/property_progression_manager.rs
+++ b/src/property_progression_manager.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ixa::{
     define_data_plugin, Context, ContextPeopleExt, IxaError, PersonProperty,
-    PersonPropertyChangeEvent,
+    PersonPropertyChangeEvent, PluginContext,
 };
 use serde::Deserialize;
 
@@ -41,28 +41,9 @@ define_data_plugin!(
     PropertyProgressionsContainer::default()
 );
 
-pub trait ContextPropertyProgressionExt {
+pub trait ContextPropertyProgressionExt: PluginContext {
     /// Registers a method that provides a sequence of person property values and times, and
     /// automatically changes the values of person properties according to that sequence.
-    fn register_property_progression<P: PersonProperty + 'static>(
-        &mut self,
-        property: P,
-        tracer: impl Progression<P> + 'static,
-    );
-}
-
-impl<P> NaturalHistoryParameterLibrary for P
-where
-    P: PersonProperty + 'static,
-{
-    fn library_size(&self, context: &Context) -> usize {
-        let container = context.get_data_container(PropertyProgressions).unwrap();
-        let progressions = container.progressions.get(&TypeId::of::<P>()).unwrap();
-        progressions.len()
-    }
-}
-
-impl ContextPropertyProgressionExt for Context {
     fn register_property_progression<P: PersonProperty + 'static>(
         &mut self,
         property: P,
@@ -92,6 +73,18 @@ impl ContextPropertyProgressionExt for Context {
                 }
             });
         }
+    }
+}
+impl ContextPropertyProgressionExt for Context {}
+
+impl<P> NaturalHistoryParameterLibrary for P
+where
+    P: PersonProperty + 'static,
+{
+    fn library_size(&self, context: &Context) -> usize {
+        let container = context.get_data_container(PropertyProgressions).unwrap();
+        let progressions = container.progressions.get(&TypeId::of::<P>()).unwrap();
+        progressions.len()
     }
 }
 

--- a/src/rate_fns/rate_fn_storage.rs
+++ b/src/rate_fns/rate_fn_storage.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
-use ixa::{define_data_plugin, define_rng, Context, ContextRandomExt, IxaError, PersonId};
+use ixa::{
+    define_data_plugin, define_rng, Context, ContextRandomExt, IxaError, PersonId, PluginContext,
+};
 use serde::Deserialize;
 
 use crate::{
@@ -36,12 +38,7 @@ define_data_plugin!(
     RateFnContainer { rates: Vec::new() }
 );
 
-pub trait InfectiousnessRateExt {
-    fn add_rate_fn(&mut self, dist: impl InfectiousnessRateFn + 'static);
-    fn get_person_rate_fn(&self, person_id: PersonId) -> &dyn InfectiousnessRateFn;
-}
-
-impl InfectiousnessRateExt for Context {
+pub trait InfectiousnessRateExt: PluginContext + ContextNaturalHistoryParameterExt {
     fn add_rate_fn(&mut self, dist: impl InfectiousnessRateFn + 'static) {
         let container = self.get_data_container_mut(RateFnPlugin);
         container.rates.push(Box::new(dist));
@@ -55,6 +52,7 @@ impl InfectiousnessRateExt for Context {
             .as_ref()
     }
 }
+impl InfectiousnessRateExt for Context {}
 
 #[allow(clippy::missing_panics_doc)]
 /// Turn the information specified in the global parameter `infectiousness_rate_fn` into actual


### PR DESCRIPTION
Implemented the `PluginContext` syntax for defining trait extensions on Context.

### Issues encountered
* [ ] Some methods contain dependencies on functions that call `Context`, which depend on calling `some_fn(&self)` and therefore can't be declared automatically (see `ContextTransmissionModifierExt`, and `ContextNaturalHistoryParameterExt`). Solution: declare these functions, as before, in the trait extension and write out the function in the `impl` block.
* [ ] Privacy bounds calling internal private trait extensions within public trait extensions (see `ContextSettingExt`). Solution: `allow` privacy bounds warning for calling internal extensions.