### PR TITLE
Dynamic batch size from avg household size

### DIFF
--- a/scripts/create_synthetic_population.R
+++ b/scripts/create_synthetic_population.R
@@ -117,7 +117,15 @@ house_counter <- 1
 list_counter <- 1
 sampled_pop <- 0
 while (sampled_pop < population_size) {
-  batch_size <- min(100, population_size - sampled_pop)
+  # Sample up to 2,000 households so as not to take whole data set
+  if (sampled_pop > 0) {
+    households_remaining <- (population_size - sampled_pop) / 
+      (sampled_pop / house_counter)
+    preferred_batch_size <- max(1, floor(0.95 * households_remaining))
+    batch_size <- min(2000, preferred_batch_size)
+  } else {
+    batch_size <- 30
+  }
   house_sample <- household_pums |>
     sample_n(batch_size, weight = WGTP) |>
     mutate(house_number = house_counter:(house_counter + batch_size - 1)) |>

--- a/scripts/create_synthetic_population.R
+++ b/scripts/create_synthetic_population.R
@@ -116,13 +116,13 @@ synth_pop_list <- vector("list", population_size)
 house_counter <- 1
 list_counter <- 1
 sampled_pop <- 0
+household_sample_cap <- 2000
 while (sampled_pop < population_size) {
-  # Sample up to 2,000 households so as not to take whole data set
   if (sampled_pop > 0) {
-    households_remaining <- (population_size - sampled_pop) / 
+    households_remaining <- (population_size - sampled_pop) /
       (sampled_pop / house_counter)
     preferred_batch_size <- max(1, floor(0.95 * households_remaining))
-    batch_size <- min(2000, preferred_batch_size)
+    batch_size <- min(household_sample_cap, preferred_batch_size)
   } else {
     batch_size <- 30
   }


### PR DESCRIPTION
Improve the sampling runtime for creating a synthetic population. Batch size dynamically adjusts based on the remaining population to be sampled. A cap of 2,000 households per batch is used, with an initial batch size of 30 for the first iteration to estimate average household size.

A faster approach would use `slice_sample(n=batch_size, weight_by=WGTP)`, but this would require a `many-to-many` join.