### PR TITLE
Fixing hospital parameters and hospitalization event sequence

### DIFF
--- a/input/input.json
+++ b/input/input.json
@@ -30,8 +30,8 @@
       "facemask_efficacy": 0.2
     },
     "hospitalization_parameters": {
-      "mean_delay_to_hospitalization": 1.0,
-      "mean_duration_of_hospitalization": 10.0,
+      "mean_delay_to_hospitalization": 6.0,
+      "mean_duration_of_hospitalization": 8.0,
       "age_groups": [
         {"min": 0, "probability": 0.0},
         {"min": 5, "probability": 0.001},

--- a/src/policies/updated_guidance.rs
+++ b/src/policies/updated_guidance.rs
@@ -1,7 +1,6 @@
 use ixa::{
-    define_derived_property, define_person_property_with_default, define_rng, trace, Context,
-    ContextPeopleExt, ContextRandomExt, IxaError, PersonId, PersonPropertyChangeEvent,
-    PluginContext,
+    define_person_property_with_default, define_rng, trace, Context, ContextPeopleExt,
+    ContextRandomExt, IxaError, PersonId, PersonPropertyChangeEvent, PluginContext,
 };
 
 use crate::{
@@ -10,17 +9,12 @@ use crate::{
     parameters::{ContextParametersExt, Params},
     policies::Policies,
     settings::{ContextSettingExt, Home, ItineraryModifiers},
-    symptom_progression::{SymptomValue, Symptoms},
+    symptom_progression::PresentingWithSymptoms,
 };
 
 define_person_property_with_default!(MaskingStatus, bool, false);
 define_person_property_with_default!(IsolatingStatus, bool, false);
-define_derived_property!(PresentingWithSymptoms, bool, [Symptoms], |symptom_value| {
-    match symptom_value {
-        Some(SymptomValue::Presymptomatic) | None => false,
-        Some(_) => true,
-    }
-});
+
 define_rng!(PolicyRng);
 
 #[derive(Debug, Clone, Copy)]

--- a/src/symptom_progression.rs
+++ b/src/symptom_progression.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use ixa::rand::Rng;
 use ixa::{
-    define_person_property_with_default, define_rng, Context, ContextPeopleExt, ContextRandomExt,
-    IxaError, PersonPropertyChangeEvent,
+    define_derived_property, define_person_property_with_default, define_rng, Context,
+    ContextPeopleExt, ContextRandomExt, IxaError, PersonPropertyChangeEvent,
 };
 use serde::{Deserialize, Serialize};
 use statrs::distribution::Weibull;
@@ -29,6 +29,12 @@ pub enum SymptomValue {
 }
 
 define_person_property_with_default!(Symptoms, Option<SymptomValue>, None);
+define_derived_property!(PresentingWithSymptoms, bool, [Symptoms], |symptom_value| {
+    match symptom_value {
+        Some(SymptomValue::Presymptomatic) | None => false,
+        Some(_) => true,
+    }
+});
 
 /// Stores information about a symptom progression (presymptomatic -> category{1..=4} -> None)
 /// for a person.


### PR DESCRIPTION
This PR updates default `mean_delay_to_hospitalization` and `mean_duration_of_hospitalization` to 6 and 8 days respectively. The values were pulled from previous literature of model parameters in the [GCM experiment repo](https://github.com/cdcent/cfa-cmei-gcm-mvp-experiments/tree/etr_experiment_refactor/Documentation). 

People now begin the event sequence to enter the hospital once they start presenting with symptoms. The derived person property presenting with symptoms has been moved from the updated guidance to the symptom progression module.