### PR TITLE
Add custom computed statistics to profiling report. Fixes #248.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ serde = "1.0.217"
 serde_json = "1.0.139"
 humantime = { version = "2.1.0", optional = true }
 dyn-clone = "1.0.19"
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/src/profiling/computed_statistic.rs
+++ b/src/profiling/computed_statistic.rs
@@ -1,0 +1,90 @@
+#[cfg(feature = "profiling")]
+use super::profiling_data;
+use super::ProfilingDataContainer;
+use serde::Serialize;
+use std::fmt::Display;
+
+pub type CustomStatisticComputer =
+    Box<dyn (Fn(&ProfilingDataContainer) -> ComputedValue) + Send + Sync>;
+pub type CustomStatisticPrinter = Box<dyn (Fn(ComputedValue)) + Send + Sync>;
+
+pub(super) struct ComputedStatistic {
+    /// The label used for the statistic in the JSON report.
+    pub label: &'static str,
+    /// The computed value of the statistic.
+    pub value: ComputedValue,
+    /// The function used to compute the statistic.
+    pub computer: CustomStatisticComputer,
+    /// The function used to print the statistic to the console.
+    pub printer: CustomStatisticPrinter,
+}
+
+/// The computed value of a statistic. The "computer" returns a value of this type.
+#[derive(Clone, PartialEq, Serialize, Debug)]
+pub enum ComputedValue {
+    // The `None` case is for situations where the ability to compute a value is not guaranteed.
+    None,
+    USize(usize),
+    Int(i64),
+    Float(f64),
+    Vec(Vec<ComputedValue>),
+}
+
+impl ComputedValue {
+    pub fn is_none(&self) -> bool {
+        self == &ComputedValue::None
+    }
+}
+
+impl Default for ComputedValue {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl Display for ComputedValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ComputedValue::None => {
+                write!(f, "")
+            }
+
+            ComputedValue::USize(value) => {
+                write!(f, "{}", value)
+            }
+
+            ComputedValue::Int(value) => {
+                write!(f, "{}", value)
+            }
+
+            ComputedValue::Float(value) => {
+                write!(f, "{}", value)
+            }
+
+            ComputedValue::Vec(values) => {
+                let formatted_values = values
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>();
+                write!(f, "[{}]", formatted_values.join(", "))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "profiling")]
+pub fn add_computed_statistic(
+    label: &'static str,
+    computer: CustomStatisticComputer,
+    printer: CustomStatisticPrinter,
+) {
+    let mut container = profiling_data();
+    container.add_computed_statistic(label, computer, printer);
+}
+#[cfg(not(feature = "profiling"))]
+pub fn add_computed_statistic(
+    _label: &'static str,
+    _computer: CustomStatisticComputer,
+    _printer: CustomStatisticPrinter,
+) {
+}

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -1,13 +1,13 @@
 use super::Span;
 #[cfg(feature = "profiling")]
-use super::TOTAL_MEASURED;
-#[cfg(feature = "profiling")]
+use super::{
+    ComputedStatistic, ComputedValue, CustomStatisticComputer, CustomStatisticPrinter,
+    ACCEPTED_INFECTION_LABEL, FORECASTED_INFECTION_LABEL, TOTAL_MEASURED,
+};
 use ixa::HashMap;
 #[cfg(feature = "profiling")]
-use std::{
-    sync::{Mutex, MutexGuard, OnceLock},
-    time::{Duration, Instant},
-};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant};
 
 #[cfg(feature = "profiling")]
 static PROFILING_DATA: OnceLock<Mutex<ProfilingDataContainer>> = OnceLock::new();
@@ -18,7 +18,7 @@ static PROFILING_DATA: OnceLock<Mutex<ProfilingDataContainer>> = OnceLock::new()
 pub(super) fn profiling_data() -> MutexGuard<'static, ProfilingDataContainer> {
     #[cfg(test)]
     PROFILING_DATA
-        .get_or_init(|| Mutex::new(ProfilingDataContainer::default()))
+        .get_or_init(|| Mutex::new(ProfilingDataContainer::new()))
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
@@ -28,14 +28,13 @@ pub(super) fn profiling_data() -> MutexGuard<'static, ProfilingDataContainer> {
 pub(super) fn profiling_data() -> MutexGuard<'static, ProfilingDataContainer> {
     #[cfg(not(test))]
     PROFILING_DATA
-        .get_or_init(|| Mutex::new(ProfilingDataContainer::default()))
+        .get_or_init(|| Mutex::new(ProfilingDataContainer::new()))
         .lock()
         .unwrap()
 }
 
-#[cfg(feature = "profiling")]
 #[derive(Default)]
-pub(super) struct ProfilingDataContainer {
+pub struct ProfilingDataContainer {
     pub start_time: Option<Instant>,
     pub counts: HashMap<&'static str, usize>,
     // We store span counts with the span duration, because they are updated when
@@ -47,12 +46,46 @@ pub(super) struct ProfilingDataContainer {
     // spans. When `open_span_count` transitions from `0`, the `total_measured` span is opened.
     // When `open_span_count` transitions back to `0`, `total_measured` is closed and duration
     // is recorded.
-    pub open_span_count: usize,
-    pub coverage: Option<Instant>,
+    #[cfg(feature = "profiling")]
+    pub(super) open_span_count: usize,
+    #[cfg(feature = "profiling")]
+    pub(super) coverage: Option<Instant>,
+    // Custom computed statistics. They are wrapped in an `Option` to allow for temporarily
+    // removing them to avoid a double borrow.
+    #[cfg(feature = "profiling")]
+    pub(super) computed_statistics: Vec<Option<ComputedStatistic>>,
 }
 
 #[cfg(feature = "profiling")]
 impl ProfilingDataContainer {
+    /// Initialize a new `ProfilingDataContainer` with any default computed statistics.
+    fn new() -> Self {
+        let mut container = Self::default();
+        let computer = |container: &ProfilingDataContainer| {
+            if let (Some(accepted), Some(forecasted)) = (
+                container.get_named_count(ACCEPTED_INFECTION_LABEL),
+                container.get_named_count(FORECASTED_INFECTION_LABEL),
+            ) {
+                #[allow(clippy::cast_precision_loss)]
+                let efficiency = (accepted as f64) / (forecasted as f64) * 100.0;
+                ComputedValue::Float(efficiency)
+            } else {
+                ComputedValue::None
+            }
+        };
+        let computer: CustomStatisticComputer = Box::new(computer);
+
+        let printer = |efficiency| {
+            if let ComputedValue::Float(efficiency) = efficiency {
+                println!("Infection Forecasting Efficiency: {:.2}%", efficiency);
+            }
+        };
+        let printer: CustomStatisticPrinter = Box::new(printer);
+        container.add_computed_statistic("infection forecasting efficiency", computer, printer);
+
+        container
+    }
+
     pub fn increment_named_count(&mut self, key: &'static str) {
         self.init_start_time();
         self.counts.entry(key).and_modify(|v| *v += 1).or_insert(1);
@@ -149,6 +182,21 @@ impl ProfilingDataContainer {
 
         rows
     }
+
+    pub fn add_computed_statistic(
+        &mut self,
+        label: &'static str,
+        computer: CustomStatisticComputer,
+        printer: CustomStatisticPrinter,
+    ) {
+        let computed_stat = ComputedStatistic {
+            label,
+            value: ComputedValue::None,
+            computer,
+            printer,
+        };
+        self.computed_statistics.push(Some(computed_stat));
+    }
 }
 
 #[cfg(feature = "profiling")]
@@ -174,6 +222,6 @@ pub fn open_span(label: &'static str) -> Span {
 /// Call this if you want to explicitly close a span before the end of the scope in which the
 /// span was defined. Equivalent to `span.drop()`.
 pub fn close_span(_span: Span) {
-    // The `span` is dropped here, and `"ProfilingDataContainer::close_span` is called
+    // The `span` is dropped here, and `ProfilingDataContainer::close_span` is called
     // from `Span::drop`. Incidentally, this is the same implementation as `span.drop()`!
 }

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -1,17 +1,16 @@
 #[cfg(feature = "profiling")]
-use super::{
-    data::profiling_data, ACCEPTED_INFECTION_LABEL, FORECASTED_INFECTION_LABEL,
-    NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS,
-};
+use super::{profiling_data, ProfilingDataContainer, NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS};
 #[cfg(feature = "profiling")]
 use humantime::format_duration;
+#[cfg(feature = "profiling")]
+use std::sync::MutexGuard;
 
 /// Prints all collected profiling data.
 #[cfg(feature = "profiling")]
 pub fn print_profiling_data() {
     print_named_spans();
     print_named_counts();
-    print_forecast_efficiency();
+    print_computed_statistics();
 }
 
 #[cfg(not(feature = "profiling"))]
@@ -88,27 +87,34 @@ pub fn print_named_spans() {}
 
 /// Prints the forecast efficiency.
 #[cfg(feature = "profiling")]
-pub fn print_forecast_efficiency() {
-    let container = profiling_data();
+pub fn print_computed_statistics() {
+    let mut container: MutexGuard<'static, ProfilingDataContainer> = profiling_data();
 
-    if let (Some(accepted), Some(forecasted)) = (
-        container.get_named_count(ACCEPTED_INFECTION_LABEL),
-        container.get_named_count(FORECASTED_INFECTION_LABEL),
-    ) {
-        #[allow(clippy::cast_precision_loss)]
-        let efficiency = (accepted as f64) / (forecasted as f64) * 100.0;
-        println!();
-        println!(
-            "Infection Forecasting Efficiency: {:.2}% ({} accepted of {} forecasted)\n",
-            efficiency,
-            format_with_commas(accepted),
-            format_with_commas(forecasted)
-        );
+    // Compute first to avoid double borrow
+    let stat_count = container.computed_statistics.len();
+    if stat_count == 0 {
+        return;
+    }
+    for idx in 0..stat_count {
+        // Temporarily take the statistic, because we need immutable access to `container`.
+        let mut statistic = container.computed_statistics[idx].take().unwrap();
+        statistic.value = (statistic.computer)(&container);
+        // Return the statistic
+        container.computed_statistics[idx] = Some(statistic);
+    }
+
+    println!();
+
+    for statistic in &container.computed_statistics {
+        let statistic = statistic.as_ref().unwrap();
+        if statistic.value.is_none() {
+            continue;
+        }
+        (statistic.printer)(statistic.value.clone());
     }
 }
-
 #[cfg(not(feature = "profiling"))]
-pub fn print_forecast_efficiency() {}
+pub fn print_computed_statistics(){}
 
 /// Prints a table with aligned columns, using the first row as a header.
 /// The first column is left-aligned; remaining columns are right-aligned.

--- a/src/profiling/file.rs
+++ b/src/profiling/file.rs
@@ -1,17 +1,22 @@
 use ixa::execution_stats::ExecutionStatistics;
+#[cfg(feature = "profiling")]
+use ixa::HashMap;
+#[cfg(feature = "profiling")]
+use serde::Serialize;
 use std::path::Path;
 #[cfg(feature = "profiling")]
 use std::{
     fs::File,
     io::Write,
+    sync::MutexGuard,
     time::{Duration, SystemTime},
 };
 
 #[cfg(feature = "profiling")]
-use serde::Serialize;
-
-#[cfg(feature = "profiling")]
-use crate::profiling::{data::profiling_data, NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS};
+use super::{
+    profiling_data, ComputedValue, ProfilingDataContainer, NAMED_COUNTS_HEADERS,
+    NAMED_SPANS_HEADERS,
+};
 
 #[cfg(feature = "profiling")]
 #[derive(Serialize)]
@@ -22,6 +27,7 @@ struct ProfilingData {
     named_counts_data: Vec<(String, usize, f64)>,
     named_spans_headers: Vec<String>,
     named_spans_data: Vec<(String, usize, Duration, f64)>,
+    computed_statistics: HashMap<&'static str, ComputedValue>,
 }
 
 #[cfg(feature = "profiling")]
@@ -29,7 +35,28 @@ pub fn write_profiling_data_to_file<P: AsRef<Path>>(
     file_path: P,
     execution_statistics: ExecutionStatistics,
 ) -> std::io::Result<()> {
-    let container = profiling_data();
+    let mut container: MutexGuard<'static, ProfilingDataContainer> = profiling_data();
+
+    // Compute first to avoid double borrow
+    let stat_count = container.computed_statistics.len();
+    for idx in 0..stat_count {
+        // Temporarily take the statistic, because we need immutable access to `container`.
+        let mut statistic = container.computed_statistics[idx].take().unwrap();
+        statistic.value = (statistic.computer)(&container);
+        // Return the statistic
+        container.computed_statistics[idx] = Some(statistic);
+    }
+
+    let computed_statistics = container.computed_statistics.iter().filter_map(|stat| {
+        let stat = stat.as_ref().unwrap();
+        if stat.value.is_none() {
+            None
+        } else {
+            Some((stat.label, stat.value.clone()))
+        }
+    });
+    let computed_statistics = computed_statistics.collect::<HashMap<_, _>>(); //HashMap::from_iter(computed_statistics);
+
     let profiling_data = ProfilingData {
         date_time: SystemTime::now(),
         execution_statistics,
@@ -43,6 +70,7 @@ pub fn write_profiling_data_to_file<P: AsRef<Path>>(
             .map(|s| (*s).to_string())
             .collect(),
         named_spans_data: container.get_named_spans_table(),
+        computed_statistics,
     };
 
     let json =

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -105,12 +105,15 @@
 //! });
 //! ```
 #![allow(dead_code)]
+#![allow(unused_imports)]
 
+mod computed_statistic;
 mod data;
 mod display;
 mod file;
 
 use crate::parameters::{ContextParametersExt, Params};
+pub use computed_statistic::*;
 pub use data::*;
 pub use display::*;
 use file::write_profiling_data_to_file;


### PR DESCRIPTION
This PR is stacked on top of #244 and will be a draft until #244 is merged.

The new API this PR provides is:

```rust
pub fn add_computed_statistic(
	// The label used in the profiling JSON file
    label: &'static str,
	// A function that takes a reference to the `ProfilingDataContainer` and computes a value
    computer: CustomStatisticComputer,
	// A function that prints the computed value to the console.
    printer: CustomStatisticPrinter,
);

// The function type aliases in the above function
pub type CustomStatisticComputer =
    Box<dyn (Fn(&ProfilingDataContainer) -> ComputedValue) + Send + Sync>;
pub type CustomStatisticPrinter = Box<dyn (Fn(ComputedValue)) + Send + Sync>;

/// The computed value of a statistic. The "computer" returns a value of this type.
pub enum ComputedValue {
    // The `None` case is for situations where the ability to compute a value is not guaranteed.
    None,
    USize(usize),
    Int(i64),
    Float(f64),
    Vec(Vec<ComputedValue>),
}

// The "computer" gets an immutable reference to all counts and spans and to the start time.
pub struct ProfilingDataContainer {
    pub start_time: Option<Instant>,
    pub counts: HashMap<&'static str, usize>,
    pub spans: HashMap<&'static str, (Duration, usize)>
}
```