### PR TITLE
Track activity in settings in addition to membership for improved performance.

### DIFF
--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -8,7 +8,7 @@ use crate::infectiousness_manager::{
 use crate::parameters::{ContextParametersExt, Params};
 use crate::profiling::{increment_named_count, open_span};
 use crate::rate_fns::{load_rate_fns, InfectiousnessRateExt};
-use crate::settings::{ContextSettingExt, ItineraryChangeEvent};
+use crate::settings::ItineraryChangeEvent;
 use ixa::{
     define_data_plugin, define_rng, plan::PlanId, trace, Context, ContextPeopleExt,
     ContextRandomExt, HashMap, IxaError, PersonId, PersonPropertyChangeEvent, PluginContext,
@@ -100,9 +100,8 @@ trait ContextForecastInternalExt: PluginContext {
                 .active_plans
                 .keys()
                 .filter(|&infector| {
-                    (context.is_contact(event.person_id, *infector) && event.increases_membership)
-                        || (event.person_id == *infector
-                            && event.previous_multiplier < event.current_multiplier)
+                    event.person_id == *infector
+                        && event.previous_multiplier < event.current_multiplier
                 })
                 .copied()
                 .collect();

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -1171,6 +1171,6 @@ mod test {
         let expected_cases = expected_incidence * 5.0;
 
         let avg_successes = *successes.borrow() as f64 / n_replicates as f64;
-        assert_almost_eq!(avg_successes, expected_cases, 0.01);
+        assert_almost_eq!(avg_successes, expected_cases, 0.015);
     }
 }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -205,7 +205,7 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
         },
     );
 
-    context.subscribe_to_itinerary_change();
+    // context.subscribe_to_itinerary_change();
 
     Ok(())
 }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -1171,6 +1171,6 @@ mod test {
         let expected_cases = expected_incidence * 5.0;
 
         let avg_successes = *successes.borrow() as f64 / n_replicates as f64;
-        assert_almost_eq!(avg_successes, expected_cases, 0.015);
+        assert_almost_eq!(avg_successes, expected_cases, 0.02);
     }
 }

--- a/src/infection_propagation_loop.rs
+++ b/src/infection_propagation_loop.rs
@@ -8,10 +8,9 @@ use crate::infectiousness_manager::{
 use crate::parameters::{ContextParametersExt, Params};
 use crate::profiling::{increment_named_count, open_span};
 use crate::rate_fns::{load_rate_fns, InfectiousnessRateExt};
-use crate::settings::ItineraryChangeEvent;
 use ixa::{
-    define_data_plugin, define_rng, plan::PlanId, trace, Context, ContextPeopleExt,
-    ContextRandomExt, HashMap, IxaError, PersonId, PersonPropertyChangeEvent, PluginContext,
+    define_rng, trace, Context, ContextPeopleExt, ContextRandomExt, IxaError, PersonId,
+    PersonPropertyChangeEvent,
 };
 
 define_rng!(InfectionRng);
@@ -22,7 +21,7 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
         forecasted_total_infectiousness,
     }) = get_forecast(context, person)
     {
-        let infection_plan = context.add_plan(next_time, move |context| {
+        context.add_plan(next_time, move |context| {
             let _span = open_span("evaluate and schedule next forecast");
             increment_named_count("forecasted infection");
             if evaluate_forecast(context, person, forecasted_total_infectiousness) {
@@ -32,8 +31,6 @@ fn schedule_next_forecasted_infection(context: &mut Context, person: PersonId) {
             // Continue scheduling forecasts until the person recovers.
             schedule_next_forecasted_infection(context, person);
         });
-        // The forecast plan is added to the data container for tracking
-        context.add_forecast_plan(person, infection_plan);
     }
 }
 
@@ -44,81 +41,8 @@ fn schedule_recovery(context: &mut Context, person: PersonId) {
         increment_named_count("recovery");
         trace!("Person {person} has recovered at {recovery_time}");
         context.recover_person(person);
-        context.remove_forecast_plan(person);
     });
 }
-
-#[derive(Default)]
-struct ForecastDataContainer {
-    active_plans: HashMap<PersonId, PlanId>,
-}
-
-impl ForecastDataContainer {
-    fn get_plan(&self, person_id: PersonId) -> Option<&PlanId> {
-        self.active_plans.get(&person_id)
-    }
-    fn add_plan(&mut self, person_id: PersonId, plan_id: PlanId) -> Option<PlanId> {
-        self.active_plans.insert(person_id, plan_id)
-    }
-    fn remove_plan(&mut self, person_id: PersonId) -> Option<PlanId> {
-        self.active_plans.remove(&person_id)
-    }
-}
-
-define_data_plugin!(
-    ForecastDataPlugin,
-    ForecastDataContainer,
-    ForecastDataContainer::default()
-);
-
-trait ContextForecastInternalExt: PluginContext {
-    /// Remove person from the data container `HashMap`
-    fn remove_forecast_plan(&mut self, person_id: PersonId) {
-        let container = self.get_data_mut(ForecastDataPlugin);
-        container.remove_plan(person_id);
-    }
-    /// Add a new plan to the forecast data plugin and cancel any plan currently associated with that person
-    fn add_forecast_plan(&mut self, person_id: PersonId, plan_id: PlanId) {
-        let container = self.get_data_mut(ForecastDataPlugin);
-        container.add_plan(person_id, plan_id);
-    }
-    /// Cancel forecast but keep infector in the data map
-    fn cancel_forecast(&mut self, person_id: PersonId) {
-        let container = self.get_data(ForecastDataPlugin);
-        if let Some(active_plan) = container.get_plan(person_id) {
-            self.cancel_plan(&active_plan.clone());
-        }
-    }
-    /// Listen to itinerary changes and determine their effect on the current active forecast plans of potential infectors
-    fn subscribe_to_itinerary_change(&mut self) {
-        self.subscribe_to_event::<ItineraryChangeEvent>(move |context, event| {
-            let _span = open_span("modify infector scheduled attempts");
-            increment_named_count("canceled forecasts");
-            let container = context.get_data(ForecastDataPlugin);
-            // Check for any active forecast associated with person
-            let affected_infectors: Vec<PersonId> = container
-                .active_plans
-                .keys()
-                .filter(|&infector| {
-                    event.person_id == *infector
-                        && event.previous_multiplier < event.current_multiplier
-                })
-                .copied()
-                .collect();
-
-            // We have to re-evaluate any infectors and infectious contacts that may be new to the person with a changed itinerary,
-            // as their itinerary potentially increased membership across some settings
-            // and therefore potentially increased the infectiousness of the infector
-            for infector in affected_infectors {
-                // The infector is only removed from the data plugin once they have no more infectious potential
-                // Otherwise, itinerary changes adding individuals to their settings could lead to infection attempts
-                context.cancel_forecast(infector);
-                schedule_next_forecasted_infection(context, infector);
-            }
-        });
-    }
-}
-impl ContextForecastInternalExt for Context {}
 
 /// Takes susceptible people from the population and changes them according to a provided `seed_fn`.
 /// The total number of people seeded is distributed binomially according to the proportion to seed.
@@ -205,8 +129,6 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
         },
     );
 
-    // context.subscribe_to_itinerary_change();
-
     Ok(())
 }
 
@@ -229,8 +151,7 @@ mod test {
         define_setting_category,
         infection_propagation_loop::{
             init, schedule_next_forecasted_infection, schedule_recovery, seed_initial_infections,
-            seed_initial_recovered, ContextForecastInternalExt, InfectionStatus,
-            InfectionStatusValue,
+            seed_initial_recovered, InfectionStatus, InfectionStatusValue,
         },
         infectiousness_manager::{
             max_total_infectiousness_multiplier, InfectionContextExt, InfectionData,
@@ -1054,7 +975,6 @@ mod test {
 
         context.init_random(seed);
         load_rate_fns(&mut context).unwrap();
-        context.subscribe_to_itinerary_change();
 
         context
     }

--- a/src/infectiousness_manager.rs
+++ b/src/infectiousness_manager.rs
@@ -62,7 +62,7 @@ define_derived_property!(
 pub fn calc_total_infectiousness_multiplier(context: &Context, person_id: PersonId) -> f64 {
     let relative_transmission_potential = context.get_relative_total_transmission(person_id);
     relative_transmission_potential
-        * context.calculate_total_infectiousness_multiplier_for_person(person_id)
+        * context.calculate_current_infectiousness_multiplier_for_person(person_id)
 }
 
 /// Calculate the maximum possible scaling factor for total infectiousness
@@ -70,7 +70,7 @@ pub fn calc_total_infectiousness_multiplier(context: &Context, person_id: Person
 /// The modifier used for intrinsic infectiousness is ignored because all modifiers must
 /// be less than or equal to one.
 pub fn max_total_infectiousness_multiplier(context: &Context, person_id: PersonId) -> f64 {
-    context.calculate_total_infectiousness_multiplier_for_person(person_id)
+    context.calculate_max_infectiousness_multiplier_for_person(person_id)
 }
 
 define_rng!(ForecastRng);
@@ -78,7 +78,7 @@ define_rng!(ForecastRng);
 // Infection attempt function for a context and given `PersonId`
 pub fn infection_attempt(context: &mut Context, person_id: PersonId) -> Option<PersonId> {
     let _span = open_span("infection_attempt");
-    if let Some(setting) = context.sample_setting(person_id) {
+    if let Some(setting) = context.sample_current_setting(person_id) {
         let next_contact = context
             .sample_from_setting_with_exclusion(person_id, setting)
             .unwrap()?;

--- a/src/population_loader.rs
+++ b/src/population_loader.rs
@@ -43,11 +43,13 @@ fn create_person_from_record(
         &mut itinerary,
         context,
         SettingId::new(Home, home_id.parse()?),
+        None,
     )?;
     append_itinerary_entry(
         &mut itinerary,
         context,
         SettingId::new(CensusTract, tract.parse()?),
+        None,
     )?;
 
     // Check for school and work memberships
@@ -56,6 +58,7 @@ fn create_person_from_record(
             &mut itinerary,
             context,
             SettingId::new(School, school_string.parse()?),
+            None,
         )?;
     }
     if !workplace_string.is_empty() {
@@ -63,6 +66,7 @@ fn create_person_from_record(
             &mut itinerary,
             context,
             SettingId::new(Workplace, workplace_string.parse()?),
+            None,
         )?;
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -42,7 +42,7 @@ where
     fn id(&self) -> usize;
     fn calculate_multiplier(
         &self,
-        members: &[PersonId],
+        members: &HashSet<PersonId>,
         setting_properties: SettingProperties,
     ) -> f64;
     fn get_category_id(&self) -> &'static str;
@@ -64,7 +64,7 @@ impl<T: SettingCategory + Clone> AnySettingId for SettingId<T> {
     #[allow(clippy::cast_precision_loss)]
     fn calculate_multiplier(
         &self,
-        members: &[PersonId],
+        members: &HashSet<PersonId>,
         setting_properties: SettingProperties,
     ) -> f64 {
         ((members.len() - 1) as f64).powf(setting_properties.alpha)
@@ -111,8 +111,6 @@ pub struct ItineraryChangeEvent {
     pub previous_multiplier: f64,
     /// Multiplier from current itinerary
     pub current_multiplier: f64,
-    /// Marker that the itinerary change may result in an increase in membership
-    pub increases_membership: bool,
 }
 
 #[allow(dead_code)]
@@ -141,7 +139,7 @@ pub fn append_itinerary_entry(
     {
         let ratio = match nondefault_ratio {
             Some(user_input) => user_input,
-            None => get_itinerary_ratio(context, &setting)?
+            None => get_itinerary_ratio(context, &setting)?,
         };
         itinerary.push(ItineraryEntry::new(setting, ratio));
     }
@@ -174,54 +172,100 @@ struct SettingDataContainer {
     // For each setting type, have a map of each setting id and a list of members
     active_members: HashMap<(TypeId, usize), HashSet<PersonId>>,
     inactive_members: HashMap<(TypeId, usize), HashSet<PersonId>>,
+    all_members: HashMap<(TypeId, usize), HashSet<PersonId>>,
     itineraries: HashMap<PersonId, Vec<ItineraryEntry>>,
     modified_itineraries: HashMap<PersonId, Vec<ItineraryEntry>>,
 }
 
+#[derive(Clone, Copy)]
+enum ItinerarySelector {
+    Default,
+    Modified,
+    Current,
+}
+
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+// Inactive membership selectors are not called
+enum MembershipSelector {
+    Active,
+    Inactive,
+    Union,
+}
+
 impl SettingDataContainer {
-    fn get_setting_members(&self, setting: &dyn AnySettingId) -> HashSet<PersonId> {
-        let default = HashSet::new();
-        let active = self.get_active_setting_members(setting)
-            .unwrap_or(&default);
-        self.get_inactive_setting_members(setting)
-            .unwrap_or(&default)
-            .union(active)
-            .copied()
-            .collect()
+    fn get_setting_members(
+        &self,
+        setting: &dyn AnySettingId,
+        selector: MembershipSelector,
+    ) -> Option<&HashSet<PersonId>> {
+        match selector {
+            MembershipSelector::Active => self.get_active_setting_members(setting),
+            MembershipSelector::Inactive => self.get_inactive_setting_members(setting),
+            MembershipSelector::Union => self.get_all_setting_members(setting),
+        }
     }
     fn get_active_setting_members(&self, setting: &dyn AnySettingId) -> Option<&HashSet<PersonId>> {
         self.active_members.get(&setting.get_tuple_id())
     }
-    fn get_inactive_setting_members(&self, setting: &dyn AnySettingId) -> Option<&HashSet<PersonId>> {
+    fn get_inactive_setting_members(
+        &self,
+        setting: &dyn AnySettingId,
+    ) -> Option<&HashSet<PersonId>> {
         self.inactive_members.get(&setting.get_tuple_id())
     }
-    fn get_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
-        if let Some(modified_itinerary) = self.modified_itineraries.get(&person_id) {
-            return Some(modified_itinerary);
-        }
-
-        if let Some(itinerary) = self.itineraries.get(&person_id) {
-            return Some(itinerary);
-        }
-        None
+    fn get_all_setting_members(&self, setting: &dyn AnySettingId) -> Option<&HashSet<PersonId>> {
+        self.all_members.get(&setting.get_tuple_id())
     }
-    fn with_itinerary<F>(&self, person_id: PersonId, mut callback: F)
-    where
+    fn get_default_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
+        self.itineraries.get(&person_id)
+    }
+    fn get_modified_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
+        self.modified_itineraries.get(&person_id)
+    }
+    fn get_itinerary(
+        &self,
+        person_id: PersonId,
+        selector: ItinerarySelector,
+    ) -> Option<&Vec<ItineraryEntry>> {
+        // Assume modified is current if specified
+        match selector {
+            ItinerarySelector::Default => self.get_default_itinerary(person_id),
+            ItinerarySelector::Modified => self.get_modified_itinerary(person_id),
+            ItinerarySelector::Current => {
+                let modified = self.get_modified_itinerary(person_id);
+                if modified.is_some() {
+                    modified
+                } else {
+                    self.get_default_itinerary(person_id)
+                }
+            }
+        }
+    }
+    fn with_itinerary<F>(
+        &self,
+        person_id: PersonId,
+        itinerary_selector: ItinerarySelector,
+        membership_selector: MembershipSelector,
+        mut callback: F,
+    ) where
         F: FnMut(&dyn AnySettingId, &SettingProperties, &HashSet<PersonId>, f64),
     {
-        if let Some(itinerary) = self.get_itinerary(person_id) {
+        if let Some(itinerary) = self.get_itinerary(person_id, itinerary_selector) {
             for entry in itinerary {
                 let setting = entry.setting.as_ref();
                 let setting_props = self
                     .setting_properties
                     .get(&entry.setting.get_type_id())
                     .unwrap();
-                let members = self.get_setting_members(setting);
-                callback(setting, setting_props, &members, entry.ratio);
+                let members = self
+                    .get_setting_members(setting, membership_selector)
+                    .unwrap();
+                callback(setting, setting_props, members, entry.ratio);
             }
         }
     }
-    fn add_member_to_itinerary_setting(
+    fn activate_itinerary(
         &mut self,
         person_id: PersonId,
         itinerary: &Vec<ItineraryEntry>,
@@ -237,25 +281,45 @@ impl SettingDataContainer {
                     "Itinerary entry setting type not registered",
                 ));
             }
-            if itinerary_entry.ratio > 0.0 {
-                self.active_members
-                    .entry(itinerary_entry.setting.get_tuple_id())
-                    .or_default()
-                    .insert(person_id);
-            } else {
-                self.inactive_members
-                    .entry(itinerary_entry.setting.get_tuple_id())
-                    .or_default()
-                    .insert(person_id);
-            }
+            self.set_member_activity(
+                person_id,
+                itinerary_entry.ratio,
+                itinerary_entry.setting.get_tuple_id(),
+            );
         }
         Ok(())
     }
-    fn remove_member_from_itinerary_settings(
+    fn set_member_activity(
         &mut self,
         person_id: PersonId,
-        itinerary: Vec<ItineraryEntry>,
+        ratio: f64,
+        setting_identifier: (TypeId, usize),
     ) {
+        if ratio > 0.0 {
+            self.active_members
+                .entry(setting_identifier)
+                .or_default()
+                .insert(person_id);
+            self.inactive_members
+                .entry(setting_identifier)
+                .or_default()
+                .retain(|&x| x != person_id);
+        } else {
+            self.inactive_members
+                .entry(setting_identifier)
+                .or_default()
+                .insert(person_id);
+            self.active_members
+                .entry(setting_identifier)
+                .or_default()
+                .retain(|&x| x != person_id);
+        }
+        self.all_members
+            .entry(setting_identifier)
+            .or_default()
+            .insert(person_id);
+    }
+    fn deactivate_itinerary(&mut self, person_id: PersonId, itinerary: Vec<ItineraryEntry>) {
         for itinerary_entry in itinerary {
             self.active_members
                 .entry(itinerary_entry.setting.get_tuple_id())
@@ -264,7 +328,7 @@ impl SettingDataContainer {
             self.inactive_members
                 .entry(itinerary_entry.setting.get_tuple_id())
                 .or_default()
-                .insert(person_id);            
+                .insert(person_id);
         }
     }
 }
@@ -332,12 +396,11 @@ trait ContextSettingInternalExt: PluginContext + ContextRandomExt {
                 ))
             }
             Some(previous_itinerary) => {
-                container
-                    .remove_member_from_itinerary_settings(person_id, previous_itinerary.clone());
+                container.deactivate_itinerary(person_id, previous_itinerary.clone());
             }
         }
 
-        container.add_member_to_itinerary_setting(person_id, &itinerary)?;
+        container.activate_itinerary(person_id, &itinerary)?;
         container.modified_itineraries.insert(person_id, itinerary);
 
         Ok(())
@@ -354,9 +417,11 @@ trait ContextSettingInternalExt: PluginContext + ContextRandomExt {
             Some(itinerary_vector) => {
                 let mut modified_itinerary = Vec::<ItineraryEntry>::new();
                 for entry in itinerary_vector {
-                    if entry.setting.get_type_id() != setting.get_type_id() {
-                        modified_itinerary.push(entry.clone());
+                    let mut new_entry = entry.clone();
+                    if entry.setting.get_type_id() == setting.get_type_id() {
+                        new_entry.ratio = 0.0;
                     }
+                    modified_itinerary.push(new_entry);
                 }
                 if modified_itinerary.is_empty() {
                     return Err(IxaError::from(
@@ -382,9 +447,11 @@ trait ContextSettingInternalExt: PluginContext + ContextRandomExt {
             Some(itineraries) => {
                 let mut modified_itinerary = Vec::<ItineraryEntry>::new();
                 for entry in itineraries {
-                    if entry.setting.get_type_id() == setting.get_type_id() {
-                        modified_itinerary.push(entry.clone());
+                    let mut new_entry = entry.clone();
+                    if entry.setting.get_type_id() != setting.get_type_id() {
+                        new_entry.ratio = 0.0;
                     }
+                    modified_itinerary.push(new_entry);
                 }
                 if modified_itinerary.is_empty() {
                     return Err(IxaError::from(
@@ -413,14 +480,50 @@ trait ContextSettingInternalExt: PluginContext + ContextRandomExt {
                 .or_default()
                 .insert(setting_id);
 
-            let setting_ratio = itinerary_entry.ratio;
-            if setting_ratio < 0.0 {
+            if itinerary_entry.ratio < 0.0 {
                 return Err(IxaError::from(
                     "Setting ratio must be greater than or equal to 0".to_string(),
                 ));
             }
         }
         Ok(())
+    }
+
+    fn get_setting_members_internal(
+        &self,
+        setting: &dyn AnySettingId,
+        selector: MembershipSelector,
+    ) -> Option<&HashSet<PersonId>> {
+        self.get_data(SettingDataPlugin)
+            .get_setting_members(setting, selector)
+    }
+
+    fn calculate_max_infectiousness_multiplier_by_itinerary(
+        &self,
+        person_id: PersonId,
+        itinerary_selector: ItinerarySelector,
+    ) -> f64 {
+        let container = self.get_data(SettingDataPlugin);
+        let mut collector = 0.0;
+        container.with_itinerary(
+            person_id,
+            itinerary_selector,
+            MembershipSelector::Union,
+            |setting, setting_props, members, ratio| {
+                let multiplier: f64 = setting.calculate_multiplier(members, *setting_props);
+                collector += ratio * multiplier;
+            },
+        );
+        collector
+    }
+
+    fn get_itinerary(
+        &self,
+        person_id: PersonId,
+        selector: ItinerarySelector,
+    ) -> Option<&Vec<ItineraryEntry>> {
+        self.get_data(SettingDataPlugin)
+            .get_itinerary(person_id, selector)
     }
 }
 impl ContextSettingInternalExt for Context {}
@@ -466,43 +569,31 @@ pub trait ContextSettingExt:
 
     fn remove_modified_itinerary(&mut self, person_id: PersonId) -> Result<(), IxaError> {
         let _span = open_span("remove_modified_itinerary");
-        let previous_multiplier =
-            self.calculate_total_infectiousness_multiplier_for_person(person_id);
 
         let container = self.get_data_mut(SettingDataPlugin);
 
         // If there's a modified itinerary present, remove
         if let Some(previous_mod_itinerary) = container.modified_itineraries.get(&person_id) {
-            container
-                .remove_member_from_itinerary_settings(person_id, previous_mod_itinerary.clone());
+            container.deactivate_itinerary(person_id, previous_mod_itinerary.clone());
         }
 
         container.modified_itineraries.remove(&person_id);
 
-        // Get people back to default itinerary, if there's one
-        match container.itineraries.get(&person_id) {
-            None => {
-                return Err(IxaError::from(
-                    "Can't modify itinerary if there isn't one present",
-                ))
-            }
-            Some(default_itinerary) => {
-                for itinerary_entry in default_itinerary {
-                    container
-                        .members
-                        .entry(itinerary_entry.setting.get_tuple_id())
-                        .or_default()
-                        .push(person_id);
-                }
-            }
+        if let Some(default_itinerary) = container.itineraries.get(&person_id) {
+            container.activate_itinerary(person_id, &default_itinerary.clone())?;
+        } else {
+            return Err(IxaError::from(
+                "Can't remove modified itinerary if there isn't a default present",
+            ));
         }
-        let current_multiplier =
-            self.calculate_total_infectiousness_multiplier_for_person(person_id);
+
+        // We don't need to calculate mutliplier differences when removing a modified itinerary
+        // The previous multiplier is already the max of current and the removed modified multiplier,
+        // So the new max rate is guaranteed to bee less than or equal to the previous max rate
         self.emit_event(ItineraryChangeEvent {
             person_id,
-            previous_multiplier,
-            current_multiplier,
-            increases_membership: true,
+            previous_multiplier: 1.0,
+            current_multiplier: 0.0,
         });
         Ok(())
     }
@@ -514,16 +605,13 @@ pub trait ContextSettingExt:
     ) -> Result<(), IxaError> {
         let _span = open_span("modify_itinerary");
         let previous_multiplier =
-            self.calculate_total_infectiousness_multiplier_for_person(person_id);
-        let increases_membership;
+            self.calculate_max_infectiousness_multiplier_for_person(person_id);
         let result = match itinerary_modifier {
             ItineraryModifiers::ReplaceWith { itinerary } => {
-                increases_membership = true;
                 trace!("ItineraryModifier::Replace person {person_id} --  {itinerary:?}");
                 self.add_modified_itinerary(person_id, itinerary)
             }
             ItineraryModifiers::RestrictTo { setting } => {
-                increases_membership = false;
                 trace!(
                     "ItineraryModifier::RestrictTo person {person_id} -- {:?}",
                     setting.get_type_id()
@@ -531,7 +619,6 @@ pub trait ContextSettingExt:
                 self.limit_itinerary_by_setting_category(person_id, setting)
             }
             ItineraryModifiers::Exclude { setting } => {
-                increases_membership = false;
                 trace!(
                     "ItineraryModifier::Exclude person {person_id}-- {:?}",
                     setting.get_type_id()
@@ -540,14 +627,12 @@ pub trait ContextSettingExt:
             }
         };
 
-        let current_multiplier =
-            self.calculate_total_infectiousness_multiplier_for_person(person_id);
+        let current_multiplier = self.calculate_max_infectiousness_multiplier_for_person(person_id);
 
         self.emit_event(ItineraryChangeEvent {
             person_id,
             previous_multiplier,
             current_multiplier,
-            increases_membership,
         });
 
         result
@@ -596,37 +681,63 @@ pub trait ContextSettingExt:
         // Clean up settings that from previous itinerary, if there is one
 
         if let Some(previous_itinerary) = container.itineraries.get(&person_id) {
-            container.remove_member_from_itinerary_settings(person_id, previous_itinerary.clone());
+            container.deactivate_itinerary(person_id, previous_itinerary.clone());
         }
 
-        container.add_member_to_itinerary_setting(person_id, &itinerary)?;
+        container.activate_itinerary(person_id, &itinerary)?;
         container.itineraries.insert(person_id, itinerary);
 
         Ok(())
     }
 
-    fn get_setting_members(&self, setting: &dyn AnySettingId) -> Option<&HashSet<PersonId>> {
-        self.get_data(SettingDataPlugin)
-            .get_setting_members(setting)
+    #[allow(dead_code)]
+    fn get_current_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
+        self.get_itinerary(person_id, ItinerarySelector::Current)
     }
 
-    /// Get the total infectiousness multiplier for a person
+    #[allow(dead_code)]
+    fn get_setting_members(&self, setting: &dyn AnySettingId) -> Option<&HashSet<PersonId>> {
+        self.get_setting_members_internal(setting, MembershipSelector::Active)
+    }
+
+    /// Get the total current infectiousness multiplier for a person
     /// This is the sum of the infectiousness multipliers for each setting derived from the itinerary
+    /// with members filtered as Active and in the Current itinerary
     /// These are generated without modification from the general formula of ratio * (N - 1) ^ alpha
-    /// where N is the number of members in the setting
-    fn calculate_total_infectiousness_multiplier_for_person(&self, person_id: PersonId) -> f64 {
+    /// where N is the number of active members in the setting
+    fn calculate_current_infectiousness_multiplier_for_person(&self, person_id: PersonId) -> f64 {
         let container = self.get_data(SettingDataPlugin);
         let mut collector = 0.0;
-        container.with_itinerary(person_id, |setting, setting_props, members, ratio| {
-            let multiplier = setting.calculate_multiplier(members, *setting_props);
-            collector += ratio * multiplier;
-        });
+        container.with_itinerary(
+            person_id,
+            ItinerarySelector::Current,
+            MembershipSelector::Active,
+            |setting, setting_props, members, ratio| {
+                let multiplier: f64 = if members.is_empty() {
+                    0.0
+                } else {
+                    setting.calculate_multiplier(members, *setting_props)
+                };
+                collector += ratio * multiplier;
+            },
+        );
         collector
     }
-
-    // Perhaps setting ids should include type and id so that one can have a vector of setting ids
-    fn get_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
-        self.get_data(SettingDataPlugin).get_itinerary(person_id)
+    /// Get the maximum infectiousness multiplier for a person across all itineraries
+    /// This is the sum of the infectiousness multipliers for each setting derived from both the
+    /// default and modified itineraries of the person.
+    /// These are generated without modification from the general formula of ratio * (N - 1) ^ alpha
+    /// where N is the number of all active and inactive members in the setting
+    fn calculate_max_infectiousness_multiplier_for_person(&self, person_id: PersonId) -> f64 {
+        let default_collector = self.calculate_max_infectiousness_multiplier_by_itinerary(
+            person_id,
+            ItinerarySelector::Default,
+        );
+        let modified_collector = self.calculate_max_infectiousness_multiplier_by_itinerary(
+            person_id,
+            ItinerarySelector::Modified,
+        );
+        f64::max(modified_collector, default_collector)
     }
 
     fn sample_from_setting_with_exclusion(
@@ -635,51 +746,51 @@ pub trait ContextSettingExt:
         setting: &dyn AnySettingId,
     ) -> Result<Option<PersonId>, IxaError> {
         let _span = open_span("get_contact");
-        if let Some(members) = self.get_setting_members(setting) {
-            let other_members: Vec<PersonId> = members.extract_if(|&p| p == person_id).collect();
-            if other_members.is_empty() {
+        if let Some(members) =
+            self.get_setting_members_internal(setting, MembershipSelector::Active)
+        {
+            if members.get(&person_id).is_some() && members.len() == 1 {
                 return Ok(None);
-            } else {
-                let contact_id = other_members[self.sample_range(SettingsRng, 0..other_members.len())];
-                return Ok(Some(contact_id))
             }
-        } else {
-            Err(IxaError::from("Group membership is None"))
+            let members: Vec<PersonId> = members.iter().copied().collect();
+            let mut contact_id;
+            loop {
+                contact_id = members[self.sample_range(SettingsRng, 0..members.len())];
+                if contact_id != person_id {
+                    break;
+                }
+            }
+            return Ok(Some(contact_id));
         }
+        Err(IxaError::from("Group membership is None"))
     }
 
-    fn sample_setting(&self, person_id: PersonId) -> Option<&dyn AnySettingId> {
+    fn sample_current_setting(&self, person_id: PersonId) -> Option<&dyn AnySettingId> {
         let _span = open_span("sample_setting");
         let container = self.get_data(SettingDataPlugin);
         let mut itinerary_multiplier = Vec::new();
-        container.with_itinerary(person_id, |setting, setting_props, members, ratio| {
-            let multiplier = setting.calculate_multiplier(members, *setting_props);
-            itinerary_multiplier.push(ratio * multiplier);
-        });
+        container.with_itinerary(
+            person_id,
+            ItinerarySelector::Current,
+            MembershipSelector::Active,
+            |setting, setting_props, members, ratio| {
+                let multiplier = if members.is_empty() {
+                    0.0
+                } else {
+                    setting.calculate_multiplier(members, *setting_props)
+                };
+                itinerary_multiplier.push(ratio * multiplier);
+            },
+        );
 
         let setting_index = self.sample_weighted(SettingsRng, &itinerary_multiplier);
 
-        if let Some(itinerary) = self.get_itinerary(person_id) {
+        if let Some(itinerary) = self.get_itinerary(person_id, ItinerarySelector::Current) {
             let itinerary_entry = &itinerary[setting_index];
             Some(itinerary_entry.setting.as_ref())
         } else {
             None
         }
-    }
-    fn is_contact(&self, person_id: PersonId, potential_contact: PersonId) -> bool {
-        let container = self.get_data(SettingDataPlugin);
-        if let Some(itinerary) = self.get_itinerary(person_id) {
-            for itinerary_entry in itinerary {
-                if let Some(members) =
-                    container.get_setting_members(itinerary_entry.setting.as_ref())
-                {
-                    if members.contains(&potential_contact) {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
     }
 }
 impl ContextSettingExt for Context {}
@@ -1100,7 +1211,7 @@ mod test {
         let alpha_s = context.get_setting_properties(&School).unwrap().alpha;
 
         let inf_multiplier =
-            context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
+            context.calculate_max_infectiousness_multiplier_for_person(person_0.unwrap());
         let expected_multiplier = (1.0 / 3.0) * (2_f64).powf(alpha_h)
             + (1.0 / 3.0) * (4_f64).powf(alpha_w)
             + (1.0 / 3.0) * (1_f64).powf(alpha_s);
@@ -1138,7 +1249,7 @@ mod test {
         assert_eq!(s_members.len(), 1);
 
         let inf_multiplier =
-            context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
+            context.calculate_max_infectiousness_multiplier_for_person(person_0.unwrap());
         let expected_multiplier = (0.95) * (2_f64).powf(alpha_h) + (0.05) * (4_f64).powf(alpha_w);
         assert_almost_eq!(inf_multiplier, expected_multiplier, 0.001);
 
@@ -1163,7 +1274,7 @@ mod test {
         assert_eq!(s_members.len(), 2);
 
         let inf_multiplier =
-            context.calculate_total_infectiousness_multiplier_for_person(person_0.unwrap());
+            context.calculate_max_infectiousness_multiplier_for_person(person_0.unwrap());
         let expected_multiplier = (1.0 / 3.0) * (2_f64).powf(alpha_h)
             + (1.0 / 3.0) * (4_f64).powf(alpha_w)
             + (1.0 / 3.0) * (1_f64).powf(alpha_s);
@@ -1425,7 +1536,7 @@ mod test {
         context.add_itinerary(person, itinerary).unwrap();
 
         // If only registered at home, total infectiousness multiplier should be (6 - 1) ^ (alpha)
-        let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person);
+        let inf_multiplier = context.calculate_max_infectiousness_multiplier_for_person(person);
         assert_almost_eq!(inf_multiplier, f64::from(6 - 1).powf(0.1), 0.0);
 
         // If person's itinerary is changed for two settings,
@@ -1447,7 +1558,7 @@ mod test {
         assert_eq!(members_tract.len(), 6);
 
         let inf_multiplier_two_settings =
-            context.calculate_total_infectiousness_multiplier_for_person(person);
+            context.calculate_max_infectiousness_multiplier_for_person(person);
 
         let alpha_h = context.get_setting_properties(&Home).unwrap().alpha;
         let alpha_ct = context.get_setting_properties(&CensusTract).unwrap().alpha;
@@ -1495,18 +1606,18 @@ mod test {
         // When person a is used to select a setting for contact, it should return Home. While they are
         // also a member of CensusTract, since they are the only member the multiplier used to weight the
         // selection is 0.0 from calculate_multiplier. Thus the probability CensusTract is selected is 0.0.
-        let setting_id = context.sample_setting(person_a).unwrap();
+        let setting_id = context.sample_current_setting(person_a).unwrap();
         assert_eq!(setting_id.get_type_id(), TypeId::of::<Home>());
         assert_eq!(setting_id.id(), 0);
 
-        let setting_id = context.sample_setting(person_b).unwrap();
+        let setting_id = context.sample_current_setting(person_b).unwrap();
         assert_eq!(setting_id.get_type_id(), TypeId::of::<Home>());
         assert_eq!(setting_id.id(), 0);
 
         let person_c = context.add_person(()).unwrap();
         let itinerary_c = vec![ItineraryEntry::new(SettingId::new(CensusTract, 0), 0.5)];
         context.add_itinerary(person_c, itinerary_c).unwrap();
-        let setting_id = context.sample_setting(person_c).unwrap();
+        let setting_id = context.sample_current_setting(person_c).unwrap();
         assert_eq!(setting_id.get_type_id(), TypeId::of::<CensusTract>());
         assert_eq!(setting_id.id(), 0);
     }
@@ -1545,7 +1656,7 @@ mod test {
         let itinerary_b = vec![ItineraryEntry::new(SettingId::new(Home, 0), 1.0)];
         context.add_itinerary(person_a, itinerary_a).unwrap();
         context.add_itinerary(person_b, itinerary_b).unwrap();
-        let setting_id = context.sample_setting(person_a).unwrap();
+        let setting_id = context.sample_current_setting(person_a).unwrap();
         let members = context.get_setting_members(setting_id).unwrap();
         assert!(members.contains(&person_a));
 
@@ -1637,14 +1748,14 @@ mod test {
         let mut itinerary = vec![];
 
         // Test appending a valid entry
-        append_itinerary_entry(&mut itinerary, &context, SettingId::new(Home, 1)).unwrap();
+        append_itinerary_entry(&mut itinerary, &context, SettingId::new(Home, 1), None).unwrap();
         assert_eq!(itinerary.len(), 1);
         assert_eq!(itinerary[0].setting.get_type_id(), TypeId::of::<Home>());
         assert_eq!(itinerary[0].setting.id(), 1);
         assert_almost_eq!(itinerary[0].ratio, 0.5, 0.0);
 
         // Test appending an entry with a different setting type
-        append_itinerary_entry(&mut itinerary, &context, SettingId::new(School, 42)).unwrap();
+        append_itinerary_entry(&mut itinerary, &context, SettingId::new(School, 42), None).unwrap();
         assert_eq!(itinerary.len(), 2);
         assert_eq!(itinerary[1].setting.get_type_id(), TypeId::of::<School>());
         assert_eq!(itinerary[1].setting.id(), 42);
@@ -1692,11 +1803,17 @@ mod test {
 
         init(&mut context);
         let mut iitinerary = vec![];
-        append_itinerary_entry(&mut iitinerary, &context, SettingId::new(Workplace, 1)).unwrap();
+        append_itinerary_entry(
+            &mut iitinerary,
+            &context,
+            SettingId::new(Workplace, 1),
+            None,
+        )
+        .unwrap();
 
         assert_eq!(iitinerary.len(), 0);
 
-        append_itinerary_entry(&mut iitinerary, &context, SettingId::new(Home, 1)).unwrap();
+        append_itinerary_entry(&mut iitinerary, &context, SettingId::new(Home, 1), None).unwrap();
         assert_eq!(iitinerary.len(), 1);
         assert_eq!(iitinerary[0].setting.get_type_id(), TypeId::of::<Home>());
     }
@@ -1741,12 +1858,20 @@ mod test {
 
         // Test creating an itinerary with all settings
         let mut itinerary = vec![];
-        append_itinerary_entry(&mut itinerary, &context, SettingId::new(Home, 1)).unwrap();
-        append_itinerary_entry(&mut itinerary, &context, SettingId::new(CensusTract, 1)).unwrap();
-        append_itinerary_entry(&mut itinerary, &context, SettingId::new(School, 1)).unwrap();
+        append_itinerary_entry(&mut itinerary, &context, SettingId::new(Home, 1), None).unwrap();
+        append_itinerary_entry(
+            &mut itinerary,
+            &context,
+            SettingId::new(CensusTract, 1),
+            None,
+        )
+        .unwrap();
+        append_itinerary_entry(&mut itinerary, &context, SettingId::new(School, 1), None).unwrap();
 
         context.add_itinerary(person, itinerary).unwrap();
-        let itinerary = context.get_itinerary(person).unwrap();
+        let itinerary = context
+            .get_itinerary(person, ItinerarySelector::Current)
+            .unwrap();
 
         let total_ratio: Vec<f64> = itinerary.iter().map(|entry| entry.ratio).collect();
         assert_eq!(total_ratio, vec![0.5, 0.25, 0.25]);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1249,7 +1249,7 @@ mod test {
         assert_eq!(s_members.len(), 1);
 
         let inf_multiplier =
-            context.calculate_max_infectiousness_multiplier_for_person(person_0.unwrap());
+            context.calculate_current_infectiousness_multiplier_for_person(person_0.unwrap());
         let expected_multiplier = (0.95) * (2_f64).powf(alpha_h) + (0.05) * (4_f64).powf(alpha_w);
         assert_almost_eq!(inf_multiplier, expected_multiplier, 0.001);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -312,7 +312,7 @@ impl SettingDataContainer {
         self.inactive_members
             .entry(setting_identifier)
             .or_default()
-            .retain(|&x| x != person_id);
+            .remove(&person_id);
         self.all_members
             .entry(setting_identifier)
             .or_default()
@@ -333,12 +333,12 @@ impl SettingDataContainer {
             }
 
             v.swap_remove(index);
-            map.retain(|&p, _| p != person_id);
+            map.remove(&person_id);
 
             self.active_members_set
                 .entry(setting_identifier)
                 .or_default()
-                .retain(|&p| p != person_id);
+                .remove(&person_id);
         }
         self.inactive_members
             .entry(setting_identifier)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1316,7 +1316,10 @@ mod test {
             ItineraryEntry::new(SettingId::new(Home, 0), 1.0),
             ItineraryEntry::new(SettingId::new(Workplace, 0), 1.0),
         ];
-        let isolation_itinerary = vec![ItineraryEntry::new(SettingId::new(Home, 0), 1.0)];
+        let isolation_itinerary = vec![
+            ItineraryEntry::new(SettingId::new(Home, 0), 1.0),
+            ItineraryEntry::new(SettingId::new(Workplace, 0), 0.0),
+        ];
 
         let _ = context.add_itinerary(person, itinerary);
 
@@ -1404,6 +1407,7 @@ mod test {
         let isolation_itinerary = vec![
             ItineraryEntry::new(SettingId::new(Home, 0), 0.95),
             ItineraryEntry::new(SettingId::new(Workplace, 0), 0.05),
+            ItineraryEntry::new(SettingId::new(School, 0), 0.0),
         ];
 
         let _ = context.modify_itinerary(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -509,9 +509,10 @@ trait ContextSettingInternalExt: PluginContext + ContextRandomExt {
             person_id,
             itinerary_selector,
             MembershipSelector::Union,
-            |setting, setting_props, members, ratio| {
+            |setting, setting_props, members, _ratio| {
                 let multiplier: f64 = setting.calculate_multiplier(members, *setting_props);
-                collector += ratio * multiplier;
+                // We want to identify the max at the setting level, not itinerary level, so that we sample at the true maximum possible rate
+                collector = f64::max(collector, multiplier);
             },
         );
         collector


### PR DESCRIPTION
Clarify the distinction between "current" and "total" infectiousness multipliers, and update the logic for handling itinerary entries and infection propagation using "activity" as a measure of presence. Ratios are adjusted to 0.0 instead of removing people as members from settings. The changes improve code clarity and correctness by using more precise function names and ensuring consistent handling of itinerary entry options.

**Changes**
* Replaced calls to `calculate_total_infectiousness_multiplier_for_person` with `calculate_current_infectiousness_multiplier_for_person` and `calculate_max_infectiousness_multiplier_for_person` in `src/infectiousness_manager.rs` that leverage active versus inactive membership counts.
* Reduced necessary checks for infector forecast plan changes in `src/infection_propagation_loop.rs` 

Speed in 100K population:
No isolation: 12s, compared to 12s on main
100% isolation: 18s, compared to >5mins on main