### PR TITLE
chore: Moved lint configuration to `Cargo.toml`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,4 +61,4 @@ repos:
         args: ["--verbose", "--"]
     -   id: clippy
         # Use 'all-targets' to run on all code, including tests and examples
-        args: ["--all-targets", "--", "-D", "warnings", "-W", "clippy::pedantic", "-A", "clippy::module-name-repetitions", "-A", "clippy::match-wildcard-for-single-variants"]
+        args: ["--all-targets"]   # let Cargo.toml [lints] control levels

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,14 @@ codegen-units = 1
 [profile.profiling]
 inherits = "release"
 debug = true
+
+[lints.rust]
+# Turn all rustc warnings into errors
+warnings = "deny"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1}
+
+module_name_repetitions = "allow"
+match_wildcard_for_single_variants = "allow"
+uninlined_format_args = "allow"


### PR DESCRIPTION
Having the lint configuration to `Cargo.toml` instead of in arguments to clippy in `.pre-commit.config.yaml` makes it a lot easier to manage and maintain. 

I also added the Clippy lint exception `uninlined_format_args`.