### PR TITLE
Switch to `IndexSet` for tracking active members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = "1.0.217"
 serde_json = "1.0.139"
 humantime = { version = "2.1.0", optional = true }
 dyn-clone = "1.0.19"
+indexmap = "2.11.0"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
Replace data structures of `HashSet`, `Vec`, and `HashMap` for active members with `IndexSet` from the `indexmap` crate. Runtime and memory usage are nearly identical for this method and the custom `HashMap`/`Vec` approach, but is more readable and creates fewer redundant structures. 

**Changes**
* Added the `indexmap` crate as a dependency
* Replaced all uses of `HashSet`, `HashMap`, and `Vec` for setting members with `IndexSet` in `SettingDataContainer` and related methods, removing redundant containers and index-tracking logic.