### PR TITLE
Hospital age groups derived person property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default = ["profiling"]
 profiling = ["humantime"]
 
 [dependencies]
-ixa = "0.3.2"
+ixa = "0.3.3"
 csv = "1.3.1"
 tempfile = "3.19.1"
 statrs = "0.18.0"


### PR DESCRIPTION
Given the change in https://github.com/CDCgov/ixa/pull/510 it is now possible to have hospital age groups be a derived person property, this means we can remove the hospital data container which stored the age group mapping. 