### PR TITLE
Remove `reports` vector

### DIFF
--- a/input/input.json
+++ b/input/input.json
@@ -20,17 +20,17 @@
     "synth_population_file": "input/people_test.csv",
     "prevalence_report": {
         "write": true,
-        "name": "person_property_count.csv",
+        "filename": "person_property_count.csv",
         "period": 1.0
     },
     "incidence_report": {
         "write": true,
-        "name": "incidence_report.csv",
+        "filename": "incidence_report.csv",
         "period": 1.0
     },
     "transmission_report": {
         "write": true,
-        "name": "transmission_report.csv"
+        "filename": "transmission_report.csv"
     },
     "guidance_policy": { "UpdatedIsolationGuidance": {
       "post_isolation_duration": 5.0,

--- a/input/input.json
+++ b/input/input.json
@@ -18,19 +18,20 @@
                                             "itinerary_specification": {"Constant": {"ratio": 0.25}}}},
     "symptom_progression_library" : {"EmpiricalFromFile": {"file": "input/library_symptom_parameters.csv"}},
     "synth_population_file": "input/people_test.csv",
-    "reports": [
-      {"TransmissionReport": {
-        "name": "transmission_report.csv"
-      }},
-      {"IncidenceReport": {
-        "name": "incidence_report.csv",
-        "period": 1.0
-      }},
-      {"PrevalenceReport": {
+    "prevalence_report": {
+        "write": true,
         "name": "person_property_count.csv",
         "period": 1.0
-      }}
-    ],
+    },
+    "incidence_report": {
+        "write": true,
+        "name": "incidence_report.csv",
+        "period": 1.0
+    },
+    "transmission_report": {
+        "write": true,
+        "name": "transmission_report.csv"
+    },
     "guidance_policy": { "UpdatedIsolationGuidance": {
       "post_isolation_duration": 5.0,
       "policy_adherence": 1.0,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -4,7 +4,7 @@ use ixa::{define_global_property, Context, ContextGlobalPropertiesExt, IxaError,
 use serde::{Deserialize, Serialize};
 
 use crate::policies::{validate_guidance_policy, Policies};
-use crate::reports::ReportType;
+use crate::reports::ReportParams;
 use crate::{hospitalizations::HospitalAgeGroups, settings::SettingProperties};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -80,8 +80,12 @@ pub struct Params {
     pub settings_properties: HashMap<CoreSettingsTypes, SettingProperties>,
     /// The path to the synthetic population file loaded in `population_loader`
     pub synth_population_file: PathBuf,
-    /// Vector of report names and period, if applicable
-    pub reports: Vec<ReportType>,
+    /// Prevalence report with a period and name required
+    pub prevalence_report: ReportParams,
+    /// Incidence report with a period and name required
+    pub incidence_report: ReportParams,
+    /// Transmission report with a name required
+    pub transmission_report: ReportParams,
     /// Facemask parameters
     /// The reduction in transmission associated with wearing a facemask.
     pub facemask_parameters: Option<FacemaskParameters>,
@@ -114,7 +118,21 @@ impl Default for Params {
             proportion_asymptomatic: 0.0,
             // Asymptomatics, if included, should act as symptomatics unless otherwise specified
             relative_infectiousness_asymptomatics: 1.0,
-            reports: Vec::new(),
+            prevalence_report: ReportParams {
+                write: false,
+                name: None,
+                period: None,
+            },
+            incidence_report: ReportParams {
+                write: false,
+                name: None,
+                period: None,
+            },
+            transmission_report: ReportParams {
+                write: false,
+                name: None,
+                period: None,
+            },
             settings_properties: HashMap::new(),
             synth_population_file: PathBuf::new(),
             facemask_parameters: None,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -120,17 +120,17 @@ impl Default for Params {
             relative_infectiousness_asymptomatics: 1.0,
             prevalence_report: ReportParams {
                 write: false,
-                name: None,
+                filename: None,
                 period: None,
             },
             incidence_report: ReportParams {
                 write: false,
-                name: None,
+                filename: None,
                 period: None,
             },
             transmission_report: ReportParams {
                 write: false,
-                name: None,
+                filename: None,
                 period: None,
             },
             settings_properties: HashMap::new(),

--- a/src/reports/incidence_report.rs
+++ b/src/reports/incidence_report.rs
@@ -239,7 +239,7 @@ mod test {
     fn test_generate_incidence_report() {
         let mut context = setup_context_with_report(ReportParams {
             write: true,
-            name: Some("output.csv".to_string()),
+            filename: Some("output.csv".to_string()),
             period: Some(2.0),
         });
 
@@ -265,7 +265,7 @@ mod test {
         let Params {
             incidence_report, ..
         } = context.get_params().clone();
-        let file_path = if let Some(name) = incidence_report.name {
+        let file_path = if let Some(name) = incidence_report.filename {
             path.join(name)
         } else {
             panic!("No report name specified");
@@ -298,7 +298,7 @@ mod test {
     fn test_age_change() {
         let mut context = setup_context_with_report(ReportParams {
             write: true,
-            name: Some("output.csv".to_string()),
+            filename: Some("output.csv".to_string()),
             period: Some(2.0),
         });
 
@@ -327,7 +327,7 @@ mod test {
         let Params {
             incidence_report, ..
         } = context.get_params().clone();
-        let file_path = if let Some(name) = incidence_report.name {
+        let file_path = if let Some(name) = incidence_report.filename {
             path.join(name)
         } else {
             panic!("No report name specified");

--- a/src/reports/incidence_report.rs
+++ b/src/reports/incidence_report.rs
@@ -208,7 +208,7 @@ mod test {
         infectiousness_manager::InfectionContextExt,
         parameters::{ContextParametersExt, GlobalParams, Params},
         rate_fns::load_rate_fns,
-        reports::ReportType,
+        reports::ReportParams,
         Age,
     };
     use ixa::{
@@ -217,14 +217,14 @@ mod test {
     use std::path::PathBuf;
     use tempfile::tempdir;
 
-    fn setup_context_with_report(report: ReportType) -> Context {
+    fn setup_context_with_report(incidence_report: ReportParams) -> Context {
         let mut context = Context::new();
         context
             .set_global_property_value(
                 GlobalParams,
                 Params {
                     max_time: 3.0,
-                    reports: vec![report],
+                    incidence_report,
                     ..Default::default()
                 },
             )
@@ -237,9 +237,10 @@ mod test {
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_generate_incidence_report() {
-        let mut context = setup_context_with_report(ReportType::IncidenceReport {
-            name: "output.csv".to_string(),
-            period: 2.0,
+        let mut context = setup_context_with_report(ReportParams {
+            write: true,
+            name: Some("output.csv".to_string()),
+            period: Some(2.0),
         });
 
         let temp_dir = tempdir().unwrap();
@@ -261,11 +262,14 @@ mod test {
         });
         context.execute();
 
-        let Params { reports, .. } = context.get_params();
-        let file_path = path.join(match &reports[0] {
-            ReportType::IncidenceReport { name, .. } => name,
-            _ => panic!("Unreachable report encountered"),
-        });
+        let Params {
+            incidence_report, ..
+        } = context.get_params().clone();
+        let file_path = if let Some(name) = incidence_report.name {
+            path.join(name)
+        } else {
+            panic!("No report name specified");
+        };
 
         assert!(file_path.exists());
         std::mem::drop(context);
@@ -292,9 +296,10 @@ mod test {
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_age_change() {
-        let mut context = setup_context_with_report(ReportType::IncidenceReport {
-            name: "output.csv".to_string(),
-            period: 2.0,
+        let mut context = setup_context_with_report(ReportParams {
+            write: true,
+            name: Some("output.csv".to_string()),
+            period: Some(2.0),
         });
 
         let temp_dir = tempdir().unwrap();
@@ -319,11 +324,14 @@ mod test {
         });
         context.execute();
 
-        let Params { reports, .. } = context.get_params();
-        let file_path = path.join(match &reports[0] {
-            ReportType::IncidenceReport { name, .. } => name,
-            _ => panic!("Unreachable report encountered"),
-        });
+        let Params {
+            incidence_report, ..
+        } = context.get_params().clone();
+        let file_path = if let Some(name) = incidence_report.name {
+            path.join(name)
+        } else {
+            panic!("No report name specified");
+        };
 
         assert!(file_path.exists());
         std::mem::drop(context);

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -9,13 +9,13 @@ pub mod transmission_report;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ReportParams {
     pub write: bool,
-    pub name: Option<String>,
+    pub filename: Option<String>,
     pub period: Option<f64>,
 }
 
 fn get_report_name(params: &ReportParams) -> Result<Option<&str>, IxaError> {
     if params.write {
-        if let Some(name) = &params.name {
+        if let Some(name) = &params.filename {
             return Ok(Some(name));
         }
 
@@ -24,7 +24,7 @@ fn get_report_name(params: &ReportParams) -> Result<Option<&str>, IxaError> {
         ));
     }
 
-    if let Some(name) = &params.name {
+    if let Some(name) = &params.filename {
         info!("Report {name} is off but has associated values with name.");
     }
     Ok(None)
@@ -128,17 +128,17 @@ mod test {
                     "synth_population_file": "input/people_test.csv",
                     "prevalence_report": {
                         "write": true,
-                        "name": "prevalence.csv",
+                        "filename": "prevalence.csv",
                         "period": 1.0
                     },
                     "incidence_report": {
                         "write": true,
-                        "name": "incidence.csv",
+                        "filename": "incidence.csv",
                         "period": 2.0
                     },
                     "transmission_report": {
                         "write": true,
-                        "name": "transmission.csv"
+                        "filename": "transmission.csv"
                     },
                     "hospitalization_parameters": {
                         "age_groups": [
@@ -161,16 +161,19 @@ mod test {
         } = context.get_params().clone();
 
         assert!(prevalence_report.write);
-        assert_eq!(prevalence_report.name, Some("prevalence.csv".to_string()));
+        assert_eq!(
+            prevalence_report.filename,
+            Some("prevalence.csv".to_string())
+        );
         assert_eq!(prevalence_report.period, Some(1.0));
 
         assert!(incidence_report.write);
-        assert_eq!(incidence_report.name, Some("incidence.csv".to_string()));
+        assert_eq!(incidence_report.filename, Some("incidence.csv".to_string()));
         assert_eq!(incidence_report.period, Some(2.0));
 
         assert!(transmission_report.write);
         assert_eq!(
-            transmission_report.name,
+            transmission_report.filename,
             Some("transmission.csv".to_string())
         );
         assert_eq!(transmission_report.period, None);
@@ -183,7 +186,7 @@ mod test {
 
         let report = ReportParams {
             write: true,
-            name: Some(name.clone()),
+            filename: Some(name.clone()),
             period: Some(period),
         };
 
@@ -202,7 +205,7 @@ mod test {
 
         let report = ReportParams {
             write: false,
-            name: Some(name),
+            filename: Some(name),
             period: Some(period),
         };
 
@@ -215,7 +218,7 @@ mod test {
 
         let no_name_report = ReportParams {
             write: true,
-            name: None,
+            filename: None,
             period: Some(period),
         };
 
@@ -241,7 +244,7 @@ mod test {
 
         let bad_period_report = ReportParams {
             write: true,
-            name: Some(name),
+            filename: Some(name),
             period: Some(bad_period),
         };
 

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -1,17 +1,51 @@
 use crate::parameters::{ContextParametersExt, Params};
-use ixa::{info, Context, HashSet, HashSetExt, IxaError};
+use ixa::{info, Context, IxaError};
 use serde::{Deserialize, Serialize};
-use std::mem::discriminant;
 
 pub mod incidence_report;
 pub mod prevalence_report;
 pub mod transmission_report;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub enum ReportType {
-    PrevalenceReport { name: String, period: f64 },
-    IncidenceReport { name: String, period: f64 },
-    TransmissionReport { name: String },
+pub struct ReportParams {
+    pub write: bool,
+    pub name: Option<String>,
+    pub period: Option<f64>,
+}
+
+fn get_report_name(params: &ReportParams) -> Result<Option<&str>, IxaError> {
+    if params.write {
+        if let Some(name) = &params.name {
+            return Ok(Some(name));
+        }
+
+        return Err(IxaError::IxaError(
+            "Reports must be provided with a name when write is set to true".to_string(),
+        ));
+    }
+
+    if let Some(name) = &params.name {
+        info!("Report {name} is off but has associated values with name.");
+    }
+    Ok(None)
+}
+
+fn get_period_report_name(params: &ReportParams) -> Result<Option<(&str, f64)>, IxaError> {
+    if let Some(name) = get_report_name(params)? {
+        if let Some(period) = params.period {
+            if period <= 0.0 {
+                return Err(IxaError::IxaError(
+                    format!("The report period must be greater than zero, found period {period} for {name} instead.")
+                ));
+            }
+            return Ok(Some((name, period)));
+        }
+
+        return Err(IxaError::IxaError(format!(
+            "Report {name} requires a period but none provided."
+        )));
+    }
+    Ok(None)
 }
 
 /// # Errors
@@ -19,63 +53,50 @@ pub enum ReportType {
 /// Will return `IxaError` if any report within the reports list cannot be added
 /// or if the period for any periodic report is less than 0.0
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
-    let Params { reports, .. } = context.get_params().clone();
+    let Params {
+        prevalence_report,
+        incidence_report,
+        transmission_report,
+        ..
+    } = context.get_params().clone();
+    let mut report_count = 0;
 
-    // Should at least one report be required?
-    if reports.is_empty() {
-        info!("No reports are being generated.");
+    if let Some((name, period)) = get_period_report_name(&prevalence_report)? {
+        prevalence_report::init(context, name, period)?;
+        info!("Generating the prevalence report.");
+        report_count += 1;
     }
-    let mut types = HashSet::new();
-
-    for report in &reports {
-        if !types.insert(discriminant(report)) {
-            return Err(IxaError::IxaError(
-                "Report types must be unique to avoid overwriting.".to_string(),
-            ));
-        }
-
-        match report {
-            ReportType::PrevalenceReport { name, period } => {
-                if period <= &0.0 {
-                    return Err(IxaError::IxaError(
-                        "The prevalence report writing period must be greater than zero."
-                            .to_string(),
-                    ));
-                }
-                prevalence_report::init(context, name.as_str(), *period)?;
-            }
-            ReportType::IncidenceReport { name, period } => {
-                if period <= &0.0 {
-                    return Err(IxaError::IxaError(
-                        "The incidence report writing period must be greater than zero."
-                            .to_string(),
-                    ));
-                }
-                incidence_report::init(context, name.as_str(), *period)?;
-            }
-            ReportType::TransmissionReport { name } => {
-                transmission_report::init(context, name.as_str())?;
-            }
-        }
+    if let Some((name, period)) = get_period_report_name(&incidence_report)? {
+        incidence_report::init(context, name, period)?;
+        info!("Generating the incidence report.");
+        report_count += 1;
     }
+    if let Some(name) = get_report_name(&transmission_report)? {
+        transmission_report::init(context, name)?;
+        info!("Generating the transmission report.");
+        report_count += 1;
+    }
+
+    info!("Generating {report_count} report(s) in total.");
+
     Ok(())
 }
 
 #[cfg(test)]
 mod test {
 
-    use crate::reports::ReportType;
+    use super::get_period_report_name;
+    use crate::reports::ReportParams;
     use crate::{
         parameters::{ContextParametersExt, Params},
         rate_fns::load_rate_fns,
     };
     use ixa::{Context, ContextGlobalPropertiesExt, ContextRandomExt, IxaError};
     use statrs::assert_almost_eq;
-    use std::path::PathBuf;
-    use tempfile::tempdir;
-
     use std::fs::File;
     use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
 
     fn setup_context_from_str(params_json: &str) -> Context {
         let temp_dir = tempdir().unwrap();
@@ -105,19 +126,20 @@ mod test {
                     "relative_infectiousness_asymptomatics": 0.0,
                     "settings_properties": {},
                     "synth_population_file": "input/people_test.csv",
-                    "reports": [
-                        {"TransmissionReport": {
-                            "name": "transmission.csv"
-                        }},
-                        {"PrevalenceReport": {
-                            "name": "prevalence.csv",
-                            "period": 1.0
-                        }},
-                        {"IncidenceReport": {
-                            "name": "incidence.csv",
-                            "period": 2.0
-                        }}
-                    ],
+                    "prevalence_report": {
+                        "write": true,
+                        "name": "prevalence.csv",
+                        "period": 1.0
+                    },
+                    "incidence_report": {
+                        "write": true,
+                        "name": "incidence.csv",
+                        "period": 2.0
+                    },
+                    "transmission_report": {
+                        "write": true,
+                        "name": "transmission.csv"
+                    },
                     "hospitalization_parameters": {
                         "age_groups": [
                             {"min": 0, "probability": 0.0},
@@ -131,79 +153,110 @@ mod test {
             }
         "#;
         let context = setup_context_from_str(params_json);
-        let Params { reports, .. } = context.get_params();
-        assert_eq!(reports.len(), 3);
-        for report in reports {
-            match report {
-                ReportType::TransmissionReport { name } => {
-                    assert_eq!(*name, "transmission.csv".to_string());
-                }
-                ReportType::PrevalenceReport { name, period } => {
-                    assert_eq!(*name, "prevalence.csv".to_string());
-                    assert_almost_eq!(*period, 1.0, 0.0);
-                }
-                ReportType::IncidenceReport { name, period } => {
-                    assert_eq!(*name, "incidence.csv".to_string());
-                    assert_almost_eq!(*period, 2.0, 0.0);
-                }
-            }
+        let Params {
+            prevalence_report,
+            incidence_report,
+            transmission_report,
+            ..
+        } = context.get_params().clone();
+
+        assert!(prevalence_report.write);
+        assert_eq!(prevalence_report.name, Some("prevalence.csv".to_string()));
+        assert_eq!(prevalence_report.period, Some(1.0));
+
+        assert!(incidence_report.write);
+        assert_eq!(incidence_report.name, Some("incidence.csv".to_string()));
+        assert_eq!(incidence_report.period, Some(2.0));
+
+        assert!(transmission_report.write);
+        assert_eq!(
+            transmission_report.name,
+            Some("transmission.csv".to_string())
+        );
+        assert_eq!(transmission_report.period, None);
+    }
+
+    #[test]
+    fn test_get_period_report_name() {
+        let name = "output.csv".to_string();
+        let period = 3.0;
+
+        let report = ReportParams {
+            write: true,
+            name: Some(name.clone()),
+            period: Some(period),
+        };
+
+        if let Some((expect_name, expect_period)) = get_period_report_name(&report).unwrap() {
+            assert_eq!(name, *expect_name);
+            assert_almost_eq!(period, expect_period, 0.0);
+        } else {
+            panic!("Expected some value for the validated name and period");
         }
     }
 
     #[test]
-    fn test_duplicate_reports() {
-        let params_json = r#"
-            {
-                "epi_isolation.GlobalParams": {
-                    "max_time": 200.0,
-                    "seed": 123,
-                    "infectiousness_rate_fn": {"Constant": {"rate": 1.0, "duration": 5.0}},
-                    "initial_incidence": 0.01,
-                    "initial_recovered": 0.0,
-                    "proportion_asymptomatic": 0.0,
-                    "relative_infectiousness_asymptomatics": 0.0,
-                    "settings_properties": {},
-                    "synth_population_file": "input/people_test.csv",
-                    "reports": [
-                        {"PrevalenceReport": {
-                            "name": "prevalence.csv",
-                            "period": 1.0
-                        }},
-                        {"PrevalenceReport": {
-                            "name": "prevalence2.csv",
-                            "period": 2.0
-                        }}
-                    ],
-                    "hospitalization_parameters": {
-                        "age_groups": [
-                            {"min": 0, "probability": 0.0},
-                            {"min": 19, "probability": 0.0},
-                            {"min": 65, "probability": 0.0}
-                        ],
-                        "mean_delay_to_hospitalization": 1.0,
-                        "mean_duration_of_hospitalization": 1.0
-                    }
-                }
-            }
-        "#;
-        let mut context = setup_context_from_str(params_json);
-        let Params { reports, .. } = context.get_params();
-        assert_eq!(reports.len(), 2);
+    fn test_get_period_report_name_nowrite() {
+        let name = "output.csv".to_string();
+        let period = 3.0;
 
-        let e = crate::reports::init(&mut context).err();
+        let report = ReportParams {
+            write: false,
+            name: Some(name),
+            period: Some(period),
+        };
 
-        match e {
+        assert_eq!(None, get_period_report_name(&report).unwrap());
+    }
+
+    #[test]
+    fn test_error_no_name() {
+        let period = 3.0;
+
+        let no_name_report = ReportParams {
+            write: true,
+            name: None,
+            period: Some(period),
+        };
+
+        match get_period_report_name(&no_name_report).err() {
             Some(IxaError::IxaError(msg)) => {
                 assert_eq!(
                     msg,
-                    "Report types must be unique to avoid overwriting.".to_string()
+                    "Reports must be provided with a name when write is set to true".to_string()
                 );
             }
             Some(ue) => panic!(
-                "Expected an error that the report types should be unique. Instead got {:?}",
+                "Expected an error the report name is required. Instead got {:?}",
                 ue.to_string()
             ),
-            None => panic!("Expected an error. Instead, validation passed with no errors."),
+            None => panic!("Expected an error. Instead validation passed with no errors."),
+        }
+    }
+
+    #[test]
+    fn test_error_bad_period() {
+        let name = "output.csv".to_string();
+        let bad_period = 0.0;
+
+        let bad_period_report = ReportParams {
+            write: true,
+            name: Some(name),
+            period: Some(bad_period),
+        };
+
+        match get_period_report_name(&bad_period_report).err() {
+            Some(IxaError::IxaError(msg)) => {
+                assert_eq!(
+                    msg,
+                    "The report period must be greater than zero, found period 0 for output.csv instead.".to_string()
+                );
+            }
+            Some(ue) => panic!(
+                "Expected an error the report name is required. Instead got {:?}",
+                ue.to_string()
+            ),
+            None => panic!("Expected an error. Instead validation passed with no errors."),
         }
     }
 }

--- a/src/reports/prevalence_report.rs
+++ b/src/reports/prevalence_report.rs
@@ -163,7 +163,7 @@ mod test {
     fn test_generate_prevalence_report() {
         let mut context = setup_context_with_report(ReportParams {
             write: true,
-            name: Some("output.csv".to_string()),
+            filename: Some("output.csv".to_string()),
             period: Some(2.0),
         });
 
@@ -189,7 +189,7 @@ mod test {
         let Params {
             prevalence_report, ..
         } = context.get_params().clone();
-        let file_path = if let Some(name) = prevalence_report.name {
+        let file_path = if let Some(name) = prevalence_report.filename {
             path.join(name)
         } else {
             panic!("No report name specified");

--- a/src/reports/transmission_report.rs
+++ b/src/reports/transmission_report.rs
@@ -97,7 +97,7 @@ mod test {
     fn test_generate_transmission_report() {
         let mut context = setup_context_with_report(ReportParams {
             write: true,
-            name: Some("output.csv".to_string()),
+            filename: Some("output.csv".to_string()),
             period: None,
         });
 
@@ -124,7 +124,7 @@ mod test {
             transmission_report,
             ..
         } = context.get_params().clone();
-        let file_path = if let Some(name) = transmission_report.name {
+        let file_path = if let Some(name) = transmission_report.filename {
             path.join(name)
         } else {
             panic!("No report name specified");


### PR DESCRIPTION
Switched from a vector of report enums to explicit, structured report parameters for each report type. 

**Changes**
* Replaces the `reports` vector of `ReportType` enums in `Params` with explicit fields for `prevalence_report`, `incidence_report`, and `transmission_report`, each using the new `ReportParams` struct. 
* Updates the JSON input format and test fixtures to use the new explicit report fields instead of the previous array-of-enums format. 
* Introduces the `ReportParams` struct, which includes `write`, `name`, and `period` fields, replacing the previous enum-based approach. Users can now use `"prevalence_report": {"write": false}` to drop the prevalence report, or keep the filename and period present while also setting to `false` to drop the report.
* Adds helper functions (`get_report_name`, `get_period_report_name`) and refactors the `init` function to validate report configuration, ensuring required fields are present and valid (e.g., `name` must be provided if `write` is true, `period` must be positive for periodic reports).
* Refactors all affected tests to use the new `ReportParams` structure and explicit report fields, ensuring test coverage for the new validation logic and configuration format.