### PR TITLE
tweaks to run recreate-synthetic & README

### DIFF
--- a/Dockerfile.R
+++ b/Dockerfile.R
@@ -1,0 +1,19 @@
+FROM rocker/r-ver:4.4
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libudunits2-dev \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    libssl-dev \
+    libproj-dev \
+    proj-data \
+    proj-bin \
+    libgdal-dev \
+    gdal-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install R packages (will use binaries if available)
+RUN Rscript -e 'install.packages(c("tidyverse", "tigris", "tidycensus", "patchwork", "data.table"))'
+WORKDIR /app
+# CMD to be passed from command line

--- a/experiments/simple-fits/recreate-synthetic/README.md
+++ b/experiments/simple-fits/recreate-synthetic/README.md
@@ -10,10 +10,36 @@ year_synth <- 2023
 population_size <- 100000
 ```
 
-Then execute
+Then execute:
+```{shell}
+docker build -t ixa-epi-isolation-r -f Dockerfile.R . && docker run --rm -v "$(pwd):/app" ixa-epi-isolation-r Rscript scripts/create_synthetic_population.R
+```
+OR:
 
 ```{shell}
 Rscript scripts/create_synthetic_population.R
+```
+
+Be sure to update `input/base.json`  with the generated file name e.g.
+```{json}
+{
+  "epi_isolation.GlobalParams": {
+    ...
+    "synth_population_file": "input/synth_pop_people_WY_1000000.csv",
+    ...
+    }
+}
+```
+
+and `input/config.yaml` e.g.
+```{yaml}
+...
+local_path:
+  target_data_file: input/synth_pop_people_WY_1000000.csv
+```
+
+Finally:
+```{shell}
 cargo build --release
 poetry run python experiments/simple-fits/recreate-synthetic/scripts/abc.py
 quarto render experiments/simple-fits/recreate-synthetic/docs/output.qmd

--- a/experiments/simple-fits/recreate-synthetic/input/base.json
+++ b/experiments/simple-fits/recreate-synthetic/input/base.json
@@ -32,7 +32,7 @@
     "transmission_report": {
         "write": false
     },
-    "synth_population_file": "input/synth_pop_people_WY_100000.csv",
+    "synth_population_file": "input/synth_pop_people_WY_1000000.csv",
     "hospitalization_parameters": {
       "mean_delay_to_hospitalization": 5.7,
       "mean_duration_of_hospitalization": 8.0,

--- a/experiments/simple-fits/recreate-synthetic/input/config.yaml
+++ b/experiments/simple-fits/recreate-synthetic/input/config.yaml
@@ -30,3 +30,4 @@ local_path:
   exe_file: target/release/epi-isolation
   sub_experiment_name: recreate-synthetic
   super_experiment_name: simple-fits
+  target_data_file: input/synth_pop_people_WY_1000000.csv

--- a/experiments/simple-fits/recreate-synthetic/scripts/abc.py
+++ b/experiments/simple-fits/recreate-synthetic/scripts/abc.py
@@ -154,8 +154,8 @@ def output_processing_function(outputs_dir):
 
     if not df.is_empty():
         df = (
-            df.with_columns((pl.col("Age") < 18).alias("pediatric"))
-            .filter(pl.col("Hospitalized") == "true")
+            df.with_columns((pl.col("age") < 18).alias("pediatric"))
+            .filter(pl.col("hospitalized") == "true")
             .group_by("t", "pediatric")
             .agg(pl.sum("count"))
         )


### PR DESCRIPTION
- Added a Dockerfile.R so `scripts/create_synthetic_population.R` can be run in a reproducible environment
- Updated `experiments/simple-fits/recreate-synthetic/README.md` to help new folks run this code
- Updated `experiments/simple-fits/recreate-synthetic/scripts/abc.py` pl.column casing to match generated csv file.